### PR TITLE
Add an Intra-style tunnel for Android

### DIFF
--- a/android/common.go
+++ b/android/common.go
@@ -1,0 +1,52 @@
+// Copyright 2019 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tun2socks
+
+import (
+	"errors"
+	"log"
+	"os"
+
+	"github.com/Jigsaw-Code/outline-go-tun2socks/tun2socks"
+)
+
+const vpnMtu = 1500
+
+func makeTunFile(fd int) (*os.File, error) {
+	if fd < 0 {
+		return nil, errors.New("Must provide a valid TUN file descriptor")
+	}
+	file := os.NewFile(uintptr(fd), "")
+	if file == nil {
+		return nil, errors.New("Failed to open TUN file descriptor")
+	}
+	return file, nil
+}
+
+func processInputPackets(tunnel tun2socks.Tunnel, tun *os.File) {
+	buffer := make([]byte, vpnMtu)
+	for tunnel.IsConnected() {
+		len, err := tun.Read(buffer)
+		if err != nil {
+			log.Printf("Failed to read packet from TUN: %v", err)
+			continue
+		}
+		if len == 0 {
+			log.Println("Read EOF from TUN")
+			continue
+		}
+		tunnel.Write(buffer)
+	}
+}

--- a/android/intra.go
+++ b/android/intra.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tun2socks
+
+import (
+	"github.com/Jigsaw-Code/outline-go-tun2socks/tun2socks"
+)
+
+// IntraTunnel embeds the tun2socks.Tunnel interface so it gets exported by gobind.
+// Intra does not need any methods beyond the basic Tunnel interface.
+type IntraTunnel interface {
+	tun2socks.Tunnel
+}
+
+// ConnectIntraTunnel reads packets from a TUN device and applies the Intra routing
+// rules.  Currently, this only consists of redirecting DNS packets to a specified
+// server; all other data flows directly to its destination.
+//
+// `fakedns` is the DNS server that the system believes it is using, in "host:port" style.
+//   The port is normally 53.
+// `udpdns` and `tcpdns` are the location of the actual DNS server being used.  For DNS
+//   tunneling in Intra, these are typically high-numbered ports on localhost.
+//
+// Throws an exception if the TUN file descriptor cannot be opened, or if the tunnel fails to
+// connect.
+func ConnectIntraTunnel(fd int, fakedns, udpdns, tcpdns string) (IntraTunnel, error) {
+	tun, err := makeTunFile(fd)
+	if err != nil {
+		return nil, err
+	}
+	tunnel, err := tun2socks.NewIntraTunnel(fakedns, udpdns, tcpdns, tun)
+	if err != nil {
+		return nil, err
+	}
+	go processInputPackets(tunnel, tun)
+	return tunnel, nil
+}

--- a/android/outline.go
+++ b/android/outline.go
@@ -16,20 +16,13 @@ package tun2socks
 
 import (
 	"errors"
-	"log"
-	"os"
 
 	"github.com/Jigsaw-Code/outline-go-tun2socks/tun2socks"
 )
 
-const vpnMtu = 1500
-
-var tun *os.File
-var tunnel AndroidTunnel
-
-// AndroidTunnel embeds the tun2socks.Tunnel interface so it gets exported by gobind.
-type AndroidTunnel interface {
-	tun2socks.Tunnel
+// OutlineTunnel embeds the tun2socks.OutlineTunnel interface so it gets exported by gobind.
+type OutlineTunnel interface {
+	tun2socks.OutlineTunnel
 }
 
 // ConnectSocksTunnel reads packets from a TUN device and routes it to a SOCKS server. Returns an
@@ -43,38 +36,18 @@ type AndroidTunnel interface {
 //
 // Throws an exception if the TUN file descriptor cannot be opened, or if the tunnel fails to
 // connect.
-func ConnectSocksTunnel(fd int, host string, port int, isUDPEnabled bool) (AndroidTunnel, error) {
+func ConnectSocksTunnel(fd int, host string, port int, isUDPEnabled bool) (OutlineTunnel, error) {
 	if port <= 0 || port > 65535 {
 		return nil, errors.New("Must provide a valid port number")
 	}
-	if fd < 0 {
-		return nil, errors.New("Must provide a valid TUN file descriptor")
-	}
-	tun = os.NewFile(uintptr(fd), "")
-	if tun == nil {
-		return nil, errors.New("Failed to open TUN file descriptor")
-	}
-	var err error
-	tunnel, err = tun2socks.NewTunnel(host, uint16(port), isUDPEnabled, tun)
+	tun, err := makeTunFile(fd)
 	if err != nil {
 		return nil, err
 	}
-	go processInputPackets()
-	return tunnel, nil
-}
-
-func processInputPackets() {
-	buffer := make([]byte, vpnMtu)
-	for tunnel.IsConnected() {
-		len, err := tun.Read(buffer)
-		if err != nil {
-			log.Printf("Failed to read packet from TUN: %v", err)
-			continue
-		}
-		if len == 0 {
-			log.Println("Read EOF from TUN")
-			continue
-		}
-		tunnel.Write(buffer)
+	tunnel, err := tun2socks.NewTunnel(host, uint16(port), isUDPEnabled, tun)
+	if err != nil {
+		return nil, err
 	}
+	go processInputPackets(tunnel, tun)
+	return tunnel, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/eycorsican/go-tun2socks v1.14.2
+	github.com/karalabe/xgo v0.0.0-20190301120235-2d6d1848fb02 // indirect
 	github.com/miekg/dns v1.1.12 // indirect
 	golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f // indirect
 	golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/eycorsican/go-tun2socks v1.13.2 h1:8AX0GW0RzsNluDaiz3j4DRpP/62ROxzlE6
 github.com/eycorsican/go-tun2socks v1.13.2/go.mod h1:itJVcg8T4Lc1r+72CNpCV/SUNO8of0z/jFeAt31cQbA=
 github.com/eycorsican/go-tun2socks v1.14.2 h1:WeceCiqIM38+/6kNygC5ucDEes6D5X5lwImFeecogTk=
 github.com/eycorsican/go-tun2socks v1.14.2/go.mod h1:itJVcg8T4Lc1r+72CNpCV/SUNO8of0z/jFeAt31cQbA=
+github.com/karalabe/xgo v0.0.0-20190301120235-2d6d1848fb02 h1:nI4Q7WQDcng8eRmi8bRP1SXlJIYLkgdgR7ZhJuzPbhs=
+github.com/karalabe/xgo v0.0.0-20190301120235-2d6d1848fb02/go.mod h1:iYGcTYIPUvEWhFo6aKUuLchs+AV4ssYdyuBbQJZGcBk=
 github.com/miekg/dns v1.1.6 h1:jVwb4GDwD65q/gtItR/lIZHjNH93QfeGxZUkzJcW9mc=
 github.com/miekg/dns v1.1.6/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.12/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -27,6 +29,7 @@ golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU
 golang.org/x/mobile v0.0.0-20190318164015-6bd122906c08 h1:REhdg1qxVTaAJcvh9BOGNgt2kd+KiUZ148XXlLp08FU=
 golang.org/x/mobile v0.0.0-20190318164015-6bd122906c08/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mobile v0.0.0-20190319155245-9487ef54b94a/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
+golang.org/x/mobile v0.0.0-20190509164839-32b2708ab171 h1:+npKrsyWLfGzZBx7xq8JP8GIYOlCfhiAhL5sFSMjqSQ=
 golang.org/x/mobile v0.0.0-20190509164839-32b2708ab171/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190313220215-9f648a60d977 h1:actzWV6iWn3GLqN8dZjzsB+CLt+gaV2+wsxroxiQI8I=

--- a/tun2socks/common.go
+++ b/tun2socks/common.go
@@ -1,0 +1,58 @@
+// Copyright 2019 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tun2socks
+
+import (
+	"errors"
+	"io"
+
+	"github.com/eycorsican/go-tun2socks/core"
+)
+
+// Tunnel represents a session on a TUN device.
+type Tunnel interface {
+	// IsConnected indicates whether the tunnel is in a connected state.
+	IsConnected() bool
+	// Disconnect disconnects the tunnel.
+	Disconnect()
+	// Write writes input data to the TUN interface.
+	Write(data []byte) (int, error)
+}
+
+type tunnel struct {
+	tunWriter   io.WriteCloser
+	lwipStack   core.LWIPStack
+	isConnected bool
+}
+
+func (t *tunnel) IsConnected() bool {
+	return t.isConnected
+}
+
+func (t *tunnel) Disconnect() {
+	if !t.isConnected {
+		return
+	}
+	t.isConnected = false
+	t.tunWriter.Close()
+	t.lwipStack.Close()
+}
+
+func (t *tunnel) Write(data []byte) (int, error) {
+	if !t.isConnected {
+		return 0, errors.New("Failed to write, network stack closed")
+	}
+	return t.lwipStack.Write(data)
+}

--- a/tun2socks/intra.go
+++ b/tun2socks/intra.go
@@ -1,0 +1,70 @@
+// Copyright 2019 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tun2socks
+
+import (
+	"errors"
+	"io"
+	"net"
+	"time"
+
+	"github.com/Jigsaw-Code/outline-go-tun2socks/tun2socks/intra"
+	"github.com/eycorsican/go-tun2socks/core"
+)
+
+type intratunnel struct {
+	*tunnel
+	fakedns net.Addr
+	udpdns  net.Addr
+	tcpdns  net.Addr
+}
+
+// NewIntraTunnel creates a connected Intra session.
+//
+// `fakedns` is the DNS server (IP and port) that will be used by apps on the TUN device.
+//    This will normally be a reserved or remote IP address, port 53.
+// `udpdns` and `tcpdns` are the actual location of the DNS server in use.
+//    These will normally be localhost with a high-numbered port.
+func NewIntraTunnel(fakedns, udpdns, tcpdns string, tunWriter io.WriteCloser) (Tunnel, error) {
+	fakednsipaddr, err := net.ResolveUDPAddr("udp", fakedns)
+	if err != nil {
+		return nil, err
+	}
+	tcpdnsipaddr, err := net.ResolveTCPAddr("tcp", tcpdns)
+	if err != nil {
+		return nil, err
+	}
+	udpdnsipaddr, err := net.ResolveUDPAddr("udp", udpdns)
+	if err != nil {
+		return nil, err
+	}
+	if tunWriter == nil {
+		return nil, errors.New("Must provide a valid TUN writer")
+	}
+	core.RegisterOutputFn(tunWriter.Write)
+	base := &tunnel{tunWriter, core.NewLWIPStack(), true}
+	s := &intratunnel{tunnel: base, fakedns: fakednsipaddr, udpdns: udpdnsipaddr, tcpdns: tcpdnsipaddr}
+	s.registerConnectionHandlers()
+	return s, nil
+}
+
+// Registers Intra's custom UDP and TCP connection handlers to the tun2socks core.
+func (t *intratunnel) registerConnectionHandlers() {
+	// RFC 5382 REQ-5 requires a timeout no shorter than 2 hours and 4 minutes.
+	timeout, _ := time.ParseDuration("2h4m")
+
+	core.RegisterUDPConnHandler(intra.NewUDPHandler(t.fakedns, t.udpdns, timeout))
+	core.RegisterTCPConnHandler(intra.NewTCPHandler(t.fakedns, t.tcpdns))
+}

--- a/tun2socks/intra/tcp.go
+++ b/tun2socks/intra/tcp.go
@@ -38,20 +38,17 @@ func NewTCPHandler(fakedns, truedns net.Addr) core.TCPConnHandler {
 }
 
 func (h *tcpHandler) handleUpload(local net.Conn, remote *net.TCPConn) {
-	// TODO: Handle half-closed sockets more correctly.
-	defer func() {
-		local.Close()
-		remote.CloseWrite()
-	}()
+	// TODO: Handle half-closed sockets more correctly if upstream
+	// changes `local` to a more detailed type than `net.Conn`.
 	io.Copy(remote, local)
+	local.Close()
+	remote.CloseWrite()
 }
 
 func (h *tcpHandler) handleDownload(local net.Conn, remote *net.TCPConn) {
-	defer func() {
-		local.Close()
-		remote.CloseRead()
-	}()
 	io.Copy(local, remote)
+	local.Close()
+	remote.CloseRead()
 }
 
 // TODO: Request upstream to make `conn` a `core.TCPConn` so we can have finer-

--- a/tun2socks/intra/tcp.go
+++ b/tun2socks/intra/tcp.go
@@ -1,0 +1,78 @@
+// Copyright 2019 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Derived from go-tun2socks's "direct" handler under the Apache 2.0 license.
+
+package intra
+
+import (
+	"io"
+	"net"
+
+	"github.com/eycorsican/go-tun2socks/common/log"
+	"github.com/eycorsican/go-tun2socks/core"
+)
+
+type tcpHandler struct {
+	fakedns net.Addr
+	truedns net.Addr
+}
+
+// NewTCPHandler returns a TCP forwarder with Intra-style behavior.
+// Currently this class only redirects DNS traffic to a
+// specified server.  (This should be rare for TCP.)
+// All other traffic is forwarded unmodified.
+func NewTCPHandler(fakedns, truedns net.Addr) core.TCPConnHandler {
+	return &tcpHandler{fakedns: fakedns, truedns: truedns}
+}
+
+func (h *tcpHandler) handleUpload(local net.Conn, remote *net.TCPConn) {
+	// TODO: Handle half-closed sockets more correctly.
+	defer func() {
+		local.Close()
+		remote.CloseWrite()
+	}()
+	io.Copy(remote, local)
+}
+
+func (h *tcpHandler) handleDownload(local net.Conn, remote *net.TCPConn) {
+	defer func() {
+		local.Close()
+		remote.CloseRead()
+	}()
+	io.Copy(local, remote)
+}
+
+// TODO: Request upstream to make `conn` a `core.TCPConn` so we can have finer-
+// grained mimicry.
+func (h *tcpHandler) Handle(conn net.Conn, target net.Addr) error {
+	// DNS override
+	// TODO: Consider whether this equality check is acceptable here.
+	// (e.g. domain names vs IPs, different serialization of IPv6)
+	if target == h.fakedns {
+		target = h.truedns
+	}
+	tcpaddr, err := net.ResolveTCPAddr(target.Network(), target.String())
+	if err != nil {
+		return err
+	}
+	c, err := net.DialTCP(target.Network(), nil, tcpaddr)
+	if err != nil {
+		return err
+	}
+	go h.handleUpload(conn, c)
+	go h.handleDownload(conn, c)
+	log.Infof("new proxy connection for target: %s:%s", target.Network(), target.String())
+	return nil
+}

--- a/tun2socks/intra/udp.go
+++ b/tun2socks/intra/udp.go
@@ -81,7 +81,6 @@ func (h *udpHandler) fetchUDPInput(conn core.UDPConn, t *tracker) {
 		t.conn.SetDeadline(time.Now().Add(h.timeout))
 		n, addr, err := t.conn.ReadFrom(buf)
 		if err != nil {
-			// log.Printf("failed to read UDP data from remote: %v", err)
 			return
 		}
 

--- a/tun2socks/intra/udp.go
+++ b/tun2socks/intra/udp.go
@@ -1,0 +1,176 @@
+// Copyright 2019 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Derived from go-tun2socks's "direct" handler under the Apache 2.0 license.
+
+package intra
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/eycorsican/go-tun2socks/common/log"
+	"github.com/eycorsican/go-tun2socks/core"
+)
+
+type tracker struct {
+	conn *net.UDPConn
+	// Parameters used to implement the single-query socket optimization:
+	fresh   bool   // True if the socket has not yet been used.
+	complex bool   // True if the socket is not a oneshot DNS query.
+	queryid uint16 // The DNS query ID for this socket, if there is one.
+}
+
+func makeTracker(conn *net.UDPConn) *tracker {
+	return &tracker{conn, true, false, 0}
+}
+
+type udpHandler struct {
+	sync.Mutex
+
+	timeout  time.Duration
+	udpConns map[core.UDPConn]*tracker
+	fakedns  net.Addr
+	truedns  net.Addr
+}
+
+// NewUDPHandler makes a UDP handler with Intra-style DNS redirection:
+// All packets are routed directly to their destination, except packets whose
+// destination is `fakedns`.  Those packets are redirected to `truedns`.
+// Similarly, packets arriving from `truedns` have the source address replaced
+// with `fakedns`.
+func NewUDPHandler(fakedns, truedns net.Addr, timeout time.Duration) core.UDPConnHandler {
+	return &udpHandler{
+		timeout:  timeout,
+		udpConns: make(map[core.UDPConn]*tracker, 8),
+		fakedns:  fakedns,
+		truedns:  truedns,
+	}
+}
+
+func queryid(data []byte) int32 {
+	if len(data) < 2 {
+		return -1
+	}
+	return 0xFFFF & ((int32(data[0]) << 8) | int32(data[1]))
+}
+
+func (h *udpHandler) fetchUDPInput(conn core.UDPConn, t *tracker) {
+	buf := core.NewBytes(core.BufSize)
+
+	defer func() {
+		h.Close(conn)
+		core.FreeBytes(buf)
+	}()
+
+	for {
+		t.conn.SetDeadline(time.Now().Add(h.timeout))
+		n, addr, err := t.conn.ReadFrom(buf)
+		if err != nil {
+			// log.Printf("failed to read UDP data from remote: %v", err)
+			return
+		}
+
+		if addr.String() == h.truedns.String() {
+			// Pretend that the reply was from the fake DNS server.
+			addr = h.fakedns
+			if n < 2 {
+				t.complex = true
+			} else {
+				responseid := queryid(buf)
+				if t.queryid != uint16(responseid) {
+					// Something very strange is going on
+					t.complex = true
+				}
+			}
+		} else {
+			// This socket has been used for non-DNS traffic.
+			t.complex = true
+		}
+		_, err = conn.WriteFrom(buf[:n], addr)
+		if err != nil {
+			log.Warnf("failed to write UDP data to TUN")
+			return
+		}
+		if !t.complex {
+			// This socket has only been used for DNS traffic, and just got a response.
+			// UDP DNS sockets are typically only used for one response.
+			return
+		}
+	}
+}
+
+func (h *udpHandler) Connect(conn core.UDPConn, target net.Addr) error {
+	bindAddr := &net.UDPAddr{IP: nil, Port: 0}
+	pc, err := net.ListenUDP(bindAddr.Network(), bindAddr)
+	if err != nil {
+		log.Errorf("failed to bind udp address")
+		return err
+	}
+	t := makeTracker(pc)
+	h.Lock()
+	h.udpConns[conn] = t
+	h.Unlock()
+	go h.fetchUDPInput(conn, t)
+	log.Infof("new proxy connection for target: %s:%s", target.Network(), target.String())
+	return nil
+}
+
+// TODO: Request upstream to make `addr` a `UDPAddr` for more efficient comparisons.
+func (h *udpHandler) DidReceiveTo(conn core.UDPConn, data []byte, addr net.Addr) error {
+	h.Lock()
+	tracker, ok1 := h.udpConns[conn]
+	h.Unlock()
+
+	if !ok1 {
+		return fmt.Errorf("connection %v->%v does not exists", conn.LocalAddr(), addr)
+	}
+
+	if addr.String() == h.fakedns.String() {
+		// Send the query to the real DNS server.
+		addr = h.truedns
+		id := queryid(data)
+		if id < 0 {
+			tracker.complex = true
+		} else if tracker.fresh {
+			tracker.queryid = uint16(id)
+		} else if tracker.queryid != uint16(id) {
+			tracker.complex = true
+		}
+	} else {
+		tracker.complex = true
+	}
+	tracker.fresh = false
+	_, err := tracker.conn.WriteTo(data, addr)
+	if err != nil {
+		log.Warnf("failed to forward UDP payload")
+		return errors.New("failed to write UDP data")
+	}
+	return nil
+}
+
+func (h *udpHandler) Close(conn core.UDPConn) {
+	conn.Close()
+
+	h.Lock()
+	defer h.Unlock()
+
+	if t, ok := h.udpConns[conn]; ok {
+		t.conn.Close()
+		delete(h.udpConns, conn)
+	}
+}


### PR DESCRIPTION
This includes a refactor to share code between Intra and Outline.
Note: This changes the name `AndroidTunnel` to `OutlineTunnel`, requiring a corresponding change in cordova-plugin-outline.

