### PR TITLE
Implement split-retry logic

### DIFF
--- a/tunnel/intra/retrier.go
+++ b/tunnel/intra/retrier.go
@@ -1,0 +1,244 @@
+package intra
+
+import (
+	"io"
+	"math/rand"
+	"net"
+	"sync"
+	"time"
+)
+
+// retrier implements the DuplexConn interface.
+type retrier struct {
+	// mutex is a lock that guards `conn`, `hello`, and `retryCompleteFlag`.
+	// These fields must not be modified except under this lock.
+	// After retryCompletedFlag is closed, these values will not be modified
+	// again so locking is no longer required for reads.
+	mutex   sync.Mutex
+	network string
+	addr    *net.TCPAddr
+	// conn is the current underlying connection.  It is only modified by the reader
+	// thread, so the reader functions may access it without acquiring a lock.
+	conn *net.TCPConn
+	// Time to wait between the first write and the first read before triggering a
+	// retry.
+	timeout time.Duration
+	// hello is the contents written before the first read.  It is initially empty,
+	// and is cleared when the first byte is received.
+	hello []byte
+	// Flag indicating when retry is finished or unnecessary.
+	retryCompleteFlag chan struct{}
+	// Flags indicating whether the caller has called CloseRead and CloseWrite.
+	readCloseFlag  chan struct{}
+	writeCloseFlag chan struct{}
+}
+
+// Helper functions for reading flags.
+// In this package, a "flag" is a thread-safe single-use status indicator that
+// starts in the "open" state and transitions to "closed" when close() is called.
+// It is implemented as a channel over which no data is ever sent.
+// Some advantages of this implementation:
+//  - The language enforces the one-way transition.
+//  - Nonblocking and blocking access are both straightforward.
+//  - Checking the status of a closed flag should be extremely fast (although currently
+//    it's not optimized: https://github.com/golang/go/issues/32529)
+func closed(c chan struct{}) bool {
+	select {
+	case <-c:
+		// The channel has been closed.
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *retrier) readClosed() bool {
+	return closed(r.readCloseFlag)
+}
+
+func (r *retrier) writeClosed() bool {
+	return closed(r.writeCloseFlag)
+}
+
+func (r *retrier) retryCompleted() bool {
+	return closed(r.retryCompleteFlag)
+}
+
+// Given timestamps immediately before and after a successful socket connection
+// (i.e. the time the SYN was sent and the time the SYNACK was received), this
+// function returns a reasonable timeout for replies to a hello sent on this socket.
+func timeout(before, after time.Time) time.Duration {
+	// These values were chosen to have a <1% false positive rate based on test data.
+	// False positives trigger an unnecessary retry, which can make connections slower, so they are
+	// worth avoiding.  However, overly long timeouts make retry slower and less useful.
+	rtt := after.Sub(before)
+	return 1200 * time.Millisecond + 2*rtt
+}
+
+// DialWithSplitRetry returns a TCP connection that transparently retries by
+// splitting the initial upstream segment if the socket closes without receiving a
+// reply.  Like net.Conn, it is intended for two-threaded use, with one thread calling
+// Read and CloseRead, and another calling Write, ReadFrom, and CloseWrite.
+func DialWithSplitRetry(network string, addr *net.TCPAddr) (DuplexConn, error) {
+	before := time.Now()
+	conn, err := net.DialTCP(network, nil, addr)
+	if err != nil {
+		return nil, err
+	}
+	after := time.Now()
+
+	r := &retrier{
+		network:           network,
+		addr:              addr,
+		conn:              conn,
+		timeout:           timeout(before, after),
+		retryCompleteFlag: make(chan struct{}),
+		readCloseFlag:     make(chan struct{}),
+		writeCloseFlag:    make(chan struct{}),
+	}
+
+	return r, nil
+}
+
+// Read-related functions.
+func (r *retrier) Read(buf []byte) (n int, err error) {
+	n, err = r.conn.Read(buf)
+	if n == 0 && err == nil {
+		// If no data was read, a nil error doesn't rule out the need for a retry.
+		return
+	}
+	if !r.retryCompleted() {
+		r.mutex.Lock()
+		if err != nil {
+			// Read failed.  Retry.
+			n, err = r.retry(buf)
+		}
+		close(r.retryCompleteFlag)
+		r.hello = nil
+		r.mutex.Unlock()
+	}
+	return
+}
+
+func (r *retrier) retry(buf []byte) (n int, err error) {
+	r.conn.Close()
+	if r.conn, err = net.DialTCP(r.network, nil, r.addr); err != nil {
+		return
+	}
+	first, second := splitHello(r.hello)
+	if _, err = r.conn.Write(first); err != nil {
+		return
+	}
+	if _, err = r.conn.Write(second); err != nil {
+		return
+	}
+	// While we were creating the new socket, the caller might have called CloseRead
+	// or CloseWrite on the old socket.  Copy that state to the new socket.
+	// CloseRead and CloseWrite are idempotent, so this is safe even if the user's
+	// action actually affected the new socket.
+	if r.readClosed() {
+		r.conn.CloseRead()
+	}
+	if r.writeClosed() {
+		r.conn.CloseWrite()
+	}
+	return r.conn.Read(buf)
+}
+
+func (r *retrier) CloseRead() error {
+	if !r.readClosed() {
+		close(r.readCloseFlag)
+	}
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.conn.CloseRead()
+}
+
+func splitHello(hello []byte) ([]byte, []byte) {
+	if len(hello) == 0 {
+		return hello, hello
+	}
+	const (
+		MIN_SPLIT int = 32
+		MAX_SPLIT int = 64
+	)
+
+	// Random number in the range [MIN_SPLIT, MAX_SPLIT]
+	s := MIN_SPLIT + rand.Intn(MAX_SPLIT+1-MIN_SPLIT)
+	limit := len(hello) / 2
+	if s > limit {
+		s = limit
+	}
+	return hello[:s], hello[s:]
+}
+
+// Write-related functions
+func (r *retrier) Write(b []byte) (n int, err error) {
+	var conn *net.TCPConn
+	// Double-checked locking pattern.  This avoids lock acquisition on
+	// every packet after retry completes, while also ensuring that r.hello is
+	// empty at steady-state.
+	if !r.retryCompleted() {
+		r.mutex.Lock()
+		if !r.retryCompleted() {
+			conn = r.conn
+			n, err = conn.Write(b)
+			r.hello = append(r.hello, b[:n]...)
+
+			// We require a response or another write within the specified timeout.
+			conn.SetReadDeadline(time.Now().Add(r.timeout))
+		}
+		r.mutex.Unlock()
+	}
+
+	if err != nil {
+		// A write error occurred on the provisional socket.  This should be handled
+		// by the retry procedure.  Block until we have a final socket (which will
+		// already have replayed b[:n]), and retry.
+		<-r.retryCompleteFlag
+		r.mutex.Lock()
+		conn = r.conn
+		r.mutex.Unlock()
+		var m int
+		m, err = conn.Write(b[n:])
+		n += m
+	}
+
+
+	if conn == nil {
+		// retryCompleted() is true, so r.conn is final and doesn't need locking.
+		n, err = r.conn.Write(b)
+	}
+	return
+}
+
+func (r *retrier) ReadFrom(reader io.Reader) (bytes int64, err error) {
+	for !r.retryCompleted() {
+		// This buffer is large enough to hold any ordinary first write
+		// without introducing extra splitting.
+		buf := make([]byte, 2048)
+		var n int
+		if n, err = reader.Read(buf); err != nil {
+			return
+		}
+		n, err = r.Write(buf[:n])
+		bytes += int64(n)
+		if err != nil {
+			return
+		}
+	}
+
+	var b int64
+	b, err = r.conn.ReadFrom(reader)
+	bytes += b
+	return
+}
+
+func (r *retrier) CloseWrite() error {
+	if !r.writeClosed() {
+		close(r.writeCloseFlag)
+	}
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.conn.CloseWrite()
+}

--- a/tunnel/intra/retrier_test.go
+++ b/tunnel/intra/retrier_test.go
@@ -1,0 +1,218 @@
+package intra
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+type setup struct {
+	t *testing.T
+	server *net.TCPListener
+	clientSide DuplexConn
+	serverSide *net.TCPConn
+	serverReceived []byte
+}
+
+func makeSetup(t *testing.T) *setup {
+	addr, err := net.ResolveTCPAddr("tcp", ":0")
+	if err != nil {
+		t.Error(err)
+	}
+	server, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		t.Error(err)
+	}
+
+	serverAddr, ok := server.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Error("Server isn't TCP?")
+	}
+	clientSide, err := DialWithSplitRetry("tcp", serverAddr)
+	if err != nil {
+		t.Error(err)
+	}
+	serverSide, err := server.AcceptTCP()
+	if err != nil {
+		t.Error(err)
+	}
+	return &setup{t, server, clientSide, serverSide, nil}
+}
+
+func makeBuffer() []byte {
+	buffer := make([]byte, 256)
+	for i := 0; i < 256; i++ {
+		buffer[i] = byte(i)
+	}
+	return buffer	
+}
+
+func send(src io.Writer, dest io.Reader, t *testing.T) []byte {
+	buffer := makeBuffer()
+	n, err := src.Write(buffer)
+	if err != nil {
+		t.Error(err)
+	}
+	if n != len(buffer) {
+		t.Errorf("Failed to write whole buffer: %d", n)
+	}
+
+	buf := make([]byte, len(buffer))
+	n, err = dest.Read(buf)
+	if err != nil {
+		t.Error(nil)
+	}
+	if n != len(buf) {
+		t.Errorf("Not enough bytes: %d", n)
+	}
+	if !bytes.Equal(buf, buffer) {
+		t.Errorf("Wrong contents")
+	}
+	return buf
+}
+
+func (s *setup) up() {
+	buf := send(s.clientSide, s.serverSide, s.t)
+	s.serverReceived = append(s.serverReceived, buf...)
+}
+
+func (s *setup) down() {
+	send(s.serverSide, s.clientSide, s.t)
+}
+
+func closeRead(closed, blocked DuplexConn, t *testing.T) {
+	closed.CloseRead()
+	// TODO: Figure out if this is detectable on the opposite side.
+}
+
+func closeWrite(closed, blocked DuplexConn, t *testing.T) {
+	closed.CloseWrite()
+	n, err := blocked.Read(make([]byte, 1))
+	if err != io.EOF || n > 0 {
+		t.Errorf("Read should have failed with EOF")
+	}
+}
+
+func (s *setup) closeReadUp() {
+	closeRead(s.clientSide, s.serverSide, s.t)
+}
+
+func (s *setup) closeWriteUp() {
+	closeWrite(s.clientSide, s.serverSide, s.t)
+}
+
+func (s *setup) closeReadDown() {
+	closeRead(s.serverSide, s.clientSide, s.t)
+}
+
+func (s *setup) closeWriteDown() {
+	closeWrite(s.serverSide, s.clientSide, s.t)
+}
+
+func (s *setup) close() {
+	s.server.Close()
+}
+
+func (s *setup) confirmRetry() {
+	done := make(chan struct{})
+	go func() {
+		buf := make([]byte, len(s.serverReceived))
+		n, err := s.clientSide.Read(buf)
+		if err != nil {
+			s.t.Error(err)
+		}
+		if n != len(buf) {
+			s.t.Error("Unexpected echo length")
+		}
+		close(done)
+	}()
+
+	var err error
+	s.serverSide, err = s.server.AcceptTCP()
+	if err != nil {
+		s.t.Errorf("Second socket failed")
+	}
+	buf := make([]byte, len(s.serverReceived))
+	var n int
+	for n < len(buf) {
+		var m int
+		m, err = s.serverSide.Read(buf[n:])
+		n += m
+		if err != nil {
+			s.t.Error(err)
+		}
+	}
+	if !bytes.Equal(buf, s.serverReceived) {
+		s.t.Errorf("Replay was corrupted")
+	}
+
+	n, err = s.serverSide.Write(buf)
+	if err != nil {
+		s.t.Error(err)
+	}
+	if n != len(buf) {
+		s.t.Errorf("Couldn't echo all bytes: %d", n)
+	}
+	<-done
+}
+
+func TestNormalConnection(t *testing.T) {
+	s := makeSetup(t)
+	s.up()
+	s.down()
+	s.closeReadUp()
+	s.closeWriteUp()
+	s.close()
+}
+
+func TestFinRetry(t *testing.T) {
+	s := makeSetup(t)
+	s.up()
+	s.serverSide.Close()
+	s.confirmRetry()
+	s.down()
+	s.closeReadUp()
+	s.closeWriteUp()
+	s.close()
+}
+
+func TestTimeoutRetry(t *testing.T) {
+	s := makeSetup(t)
+	s.up()
+	// Client should time out and retry after about 1.2 seconds
+	time.Sleep(2 * time.Second)
+	s.confirmRetry()
+	s.down()
+	s.closeReadUp()
+	s.closeWriteUp()
+	s.close()
+}
+func TestFailedRetry(t *testing.T) {
+	s := makeSetup(t)
+	s.up()
+	s.serverSide.Close()
+	s.confirmRetry()
+	s.closeReadDown()
+	s.closeWriteDown()
+	s.close()
+}
+
+func TestSequentialClose(t *testing.T) {
+	s := makeSetup(t)
+	s.up()
+	s.closeWriteUp()
+	s.down()
+	s.closeWriteDown()
+	s.close()
+}
+
+func TestBackwardsUse(t *testing.T) {
+	s := makeSetup(t)
+	s.down()
+	s.closeWriteDown()
+	s.up()
+	s.closeWriteUp()
+	s.close()
+}

--- a/tunnel/intra/udp.go
+++ b/tunnel/intra/udp.go
@@ -31,7 +31,7 @@ import (
 type UDPSocketSummary struct {
 	UploadBytes   int64 // Amount uploaded (bytes)
 	DownloadBytes int64 // Amount downloaded (bytes)
-	Duration int32 // How long the socket was open (seconds)
+	Duration      int32 // How long the socket was open (seconds)
 }
 
 type UDPListener interface {


### PR DESCRIPTION
This change introduces a split-retry pseudo-Dialer, which is used for TCP port 443.  It should match Intra's current retry behavior reasonably precisely.