### PR TITLE
Android: retrieve JNI binaries, don't strip debug symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ XGOCMD=xgo
 BUILDDIR=$(shell pwd)/build
 IMPORT_PATH=github.com/Jigsaw-Code/outline-go-tun2socks
 LDFLAGS='-s -w'
+ANDROID_LDFLAGS='-w' # Don't strip Android debug symbols so we can upload them to crash reporting tools.
 TUN2SOCKS_VERSION=v1.14.2
 TUN2SOCKS_SRC_PATH=$(GOPATH)/src/github.com/eycorsican/go-tun2socks
 TUN2SOCKS_MOD_PATH=$(GOPATH)/pkg/mod/github.com/eycorsican/go-tun2socks\@$(TUN2SOCKS_VERSION)
@@ -21,7 +22,7 @@ MACOS_ARTIFACT=$(MACOS_BUILDDIR)/Tun2socks.framework
 WINDOWS_BUILDDIR=$(BUILDDIR)/windows
 LINUX_BUILDDIR=$(BUILDDIR)/linux
 
-ANDROID_BUILD_CMD="GO111MODULE=off $(GOBIND) -a -ldflags $(LDFLAGS) -target=android -tags android -o $(ANDROID_ARTIFACT) $(IMPORT_PATH)/android $(IMPORT_PATH)/tunnel $(IMPORT_PATH)/tunnel/intra"
+ANDROID_BUILD_CMD="GO111MODULE=off $(GOBIND) -a -ldflags $(ANDROID_LDFLAGS) -target=android -tags android -work -o $(ANDROID_ARTIFACT) $(IMPORT_PATH)/android $(IMPORT_PATH)/tunnel $(IMPORT_PATH)/tunnel/intra"
 IOS_BUILD_CMD="GO111MODULE=off $(GOBIND) -a -ldflags $(LDFLAGS) -bundleid org.outline.tun2socks -target=ios/arm,ios/arm64 -tags ios -o $(IOS_ARTIFACT) $(IMPORT_PATH)/apple"
 MACOS_BUILD_CMD="GO111MODULE=off $(GOBIND) -a -ldflags $(LDFLAGS) -bundleid org.outline.tun2socks -target=ios/amd64 -tags ios -o $(MACOS_ARTIFACT) $(IMPORT_PATH)/apple"
 WINDOWS_BUILD_CMD="$(XGOCMD) -ldflags $(XGO_LDFLAGS) -tags $(XGO_BUILD_TAGS)  --targets=windows/386 -dest $(WINDOWS_BUILDDIR) $(TUN2SOCKS_SRC_PATH)/cmd/tun2socks"

--- a/build_android.sh
+++ b/build_android.sh
@@ -27,4 +27,5 @@ if [ ! -z $GO_WORK_DIR ]; then
   echo "Copying JNI binaries from: $GO_WORK_DIR"
   readonly JNI_DIR=$BUILD_DIR/jni
   mkdir -p $JNI_DIR && cp -R $GO_WORK_DIR/android/src/main/jniLibs/ $JNI_DIR/
+  rm -rf $GO_WORK_DIR
 fi


### PR DESCRIPTION
* Passes the `-work` flag to `gomobile bind` in order to get Go's working directory and copy JNI binaries.
* Stops stripping debug symbols in Android builds to enable crash reporting tools to extract them.