### PR TITLE
Ensure that retrier.conn is never nil

### DIFF
--- a/tunnel/intra/retrier.go
+++ b/tunnel/intra/retrier.go
@@ -135,9 +135,11 @@ func (r *retrier) Read(buf []byte) (n int, err error) {
 
 func (r *retrier) retry(buf []byte) (n int, err error) {
 	r.conn.Close()
-	if r.conn, err = net.DialTCP(r.network, nil, r.addr); err != nil {
+	var newConn *net.TCPConn
+	if newConn, err = net.DialTCP(r.network, nil, r.addr); err != nil {
 		return
 	}
+	r.conn = newConn
 	first, second := splitHello(r.hello)
 	r.stats.Split = int16(len(first))
 	// Set Retry to a non-nil value, indicating that a retry occurred.

--- a/tunnel/intra/retrier_test.go
+++ b/tunnel/intra/retrier_test.go
@@ -247,6 +247,21 @@ func TestFailedRetry(t *testing.T) {
 	s.checkStats(BUFSIZE, 1, false)
 }
 
+func TestDisappearingServer(t *testing.T) {
+	s := makeSetup(t)
+	s.sendUp()
+	s.close()
+	s.serverSide.Close()
+	// Try to read 1 byte to trigger the retry.
+	n, err := s.clientSide.Read(make([]byte, 1))
+	if n > 0 || err == nil {
+		t.Error("Expected read to fail")
+	}
+	s.clientSide.CloseRead()
+	s.clientSide.CloseWrite()
+	s.checkNoStats()
+}
+
 func TestSequentialClose(t *testing.T) {
 	s := makeSetup(t)
 	s.sendUp()


### PR DESCRIPTION
Previously, retrier.conn would become nil if DialTCP
failed in the retry.  This would lead to a null pointer
exception at CloseRead().