### PR TITLE
Android: increase garbage collection frequency

### DIFF
--- a/android/common.go
+++ b/android/common.go
@@ -18,11 +18,17 @@ import (
 	"errors"
 	"log"
 	"os"
+	"runtime/debug"
 
 	"github.com/Jigsaw-Code/outline-go-tun2socks/tunnel"
 )
 
 const vpnMtu = 1500
+
+func init() {
+	// Conserve memory by increasing garbage collection frequency.
+	debug.SetGCPercent(10)
+}
 
 func makeTunFile(fd int) (*os.File, error) {
 	if fd < 0 {

--- a/tunnel/outline.go
+++ b/tunnel/outline.go
@@ -62,7 +62,7 @@ func (t *outlinetunnel) SetUDPEnabled(isUDPEnabled bool) {
 		return
 	}
 	t.isUDPEnabled = isUDPEnabled
-	t.lwipStack.Close() // Close exisiting connections to avoid using the previous handlers.
+	t.lwipStack.Close() // Close existing connections to avoid using the previous handlers.
 	t.registerConnectionHandlers()
 }
 


### PR DESCRIPTION
* Increases garbage collection frequency in order to reduce Android memory usage.
* Profiled memory usage in the Outline client app before and after the change. Observed a ~9% memory usage reduction under active network conditions.

Before
![go memory 0](https://user-images.githubusercontent.com/2132122/62654527-f6fdb600-b92d-11e9-9d2e-1d94758514e6.png)

After
![go setgcpercent memory 0 (fast com)](https://user-images.githubusercontent.com/2132122/62654548-01b84b00-b92e-11e9-9554-70fe0a86f4c9.png)
