### PR TITLE
Unset deadline after handshake completes

### DIFF
--- a/tunnel/intra/retrier.go
+++ b/tunnel/intra/retrier.go
@@ -130,6 +130,8 @@ func (r *retrier) Read(buf []byte) (n int, err error) {
 			n, err = r.retry(buf)
 		}
 		close(r.retryCompleteFlag)
+		// Unset read deadline.
+		r.conn.SetReadDeadline(time.Time{})
 		r.hello = nil
 		r.mutex.Unlock()
 	}

--- a/tunnel/intra/retrier_test.go
+++ b/tunnel/intra/retrier_test.go
@@ -281,3 +281,17 @@ func TestBackwardsUse(t *testing.T) {
 	s.close()
 	s.checkNoStats()
 }
+
+// Regression test for an issue in which the initial handshake timeout
+// continued to apply after the handshake completed.
+func TestIdle(t *testing.T) {
+	s := makeSetup(t)
+	s.sendUp()
+	s.sendDown()
+	// Wait for longer than the 1.2-second response timeout
+	time.Sleep(2 * time.Second)
+	// Try to send down some more data.
+	s.sendDown()
+	s.close()
+	s.checkNoStats()
+}


### PR DESCRIPTION
This bug was causing all connections to be killed once they
went idle.