### PR TITLE
Outline Shadowsocks tunnel

### DIFF
--- a/outline/android/tun2socks.go
+++ b/outline/android/tun2socks.go
@@ -33,18 +33,20 @@ type OutlineTunnel interface {
 	tunnel.OutlineTunnel
 }
 
-// ConnectSocksTunnel reads packets from a TUN device and routes it to a SOCKS server. Returns an
-// AndroidTunnel instance and does *not* take ownership of the TUN file descriptor; the
+// ConnectShadowsocksTunnel reads packets from a TUN device and routes it to a Shadowsocks proxy server.
+// Returns an AndroidTunnel instance and does *not* take ownership of the TUN file descriptor; the
 // caller is responsible for closing after AndroidTunnel disconnects.
 //
 // `fd` is the file descriptor to the VPN TUN device. Must be set to blocking mode.
 // `host` is  IP address of the SOCKS proxy server.
 // `port` is the port of the SOCKS proxy server.
+// `password` is the password of the Shadowsocks proxy.
+// `cipher` is the encryption cipher the Shadowsocks proxy.
 // `isUDPEnabled` indicates whether the tunnel and/or network enable UDP proxying.
 //
 // Throws an exception if the TUN file descriptor cannot be opened, or if the tunnel fails to
 // connect.
-func ConnectSocksTunnel(fd int, host string, port int, isUDPEnabled bool) (OutlineTunnel, error) {
+func ConnectShadowsocksTunnel(fd int, host string, port int, password, cipher string, isUDPEnabled bool) (OutlineTunnel, error) {
 	if port <= 0 || port > 65535 {
 		return nil, errors.New("Must provide a valid port number")
 	}
@@ -52,7 +54,7 @@ func ConnectSocksTunnel(fd int, host string, port int, isUDPEnabled bool) (Outli
 	if err != nil {
 		return nil, err
 	}
-	t, err := tunnel.NewOutlineTunnel(host, uint16(port), isUDPEnabled, tun)
+	t, err := tunnel.NewOutlineTunnel(host, port, password, cipher, isUDPEnabled, tun)
 	if err != nil {
 		return nil, err
 	}

--- a/outline/shadowsocks/connectivity.go
+++ b/outline/shadowsocks/connectivity.go
@@ -76,15 +76,3 @@ func CheckServerReachable(host string, port int) error {
 	conn.Close()
 	return nil
 }
-
-// CheckUDPConnectivity determines whether UDP forwarding is supported by a Shadowsocks proxy.
-// Returns an error if the server does not support UDP.
-// TODO: remove this once we support a Shadowsocks tunnel and deprecate the SOCKS interface,
-// as we will be able to perform the UDP connectivity check directly from Go.
-func CheckUDPConnectivity(host string, port int, password, cipher string) error {
-	client, err := shadowsocks.NewClient(host, port, password, cipher)
-	if err != nil {
-		return err
-	}
-	return oss.CheckUDPConnectivityWithDNS(client, shadowsocks.NewAddr("1.1.1.1:53", "udp"))
-}

--- a/shadowsocks/tcp.go
+++ b/shadowsocks/tcp.go
@@ -1,0 +1,32 @@
+package shadowsocks
+
+import (
+	"net"
+
+	onet "github.com/Jigsaw-Code/outline-ss-server/net"
+	"github.com/Jigsaw-Code/outline-ss-server/shadowsocks"
+	"github.com/eycorsican/go-tun2socks/core"
+)
+
+type tcpHandler struct {
+	client shadowsocks.Client
+}
+
+// NewTCPHandler TODO
+func NewTCPHandler(host string, port int, password, cipher string) core.TCPConnHandler {
+	client, err := shadowsocks.NewClient(host, port, password, cipher)
+	if err != nil {
+		return nil
+	}
+	return &tcpHandler{client}
+}
+
+func (h *tcpHandler) Handle(conn net.Conn, target *net.TCPAddr) error {
+	proxyConn, err := h.client.DialTCP(nil, target.String())
+	if err != nil {
+		return err
+	}
+	// TODO: Request upstream to make `conn` a `core.TCPConn` so we can avoid this type assertion.
+	go onet.Relay(conn.(core.TCPConn), proxyConn)
+	return nil
+}

--- a/shadowsocks/tcp.go
+++ b/shadowsocks/tcp.go
@@ -12,7 +12,12 @@ type tcpHandler struct {
 	client shadowsocks.Client
 }
 
-// NewTCPHandler TODO
+// NewTCPHandler returns a Shadowsocks TCP connection handler.
+//
+// `host` is the hostname of the Shadowsocks proxy server.
+// `port` is the port of the Shadowsocks proxy server.
+// `password` is password used to authenticate to the server.
+// `cipher` is the encryption cipher of the Shadowsocks proxy.
 func NewTCPHandler(host string, port int, password, cipher string) core.TCPConnHandler {
 	client, err := shadowsocks.NewClient(host, port, password, cipher)
 	if err != nil {

--- a/shadowsocks/udp.go
+++ b/shadowsocks/udp.go
@@ -1,0 +1,88 @@
+package shadowsocks
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/Jigsaw-Code/outline-ss-server/shadowsocks"
+	"github.com/eycorsican/go-tun2socks/core"
+)
+
+type udpHandler struct {
+	sync.Mutex
+
+	client  shadowsocks.Client
+	timeout time.Duration
+	conns   map[core.UDPConn]net.PacketConn
+}
+
+// NewUDPHandler TODO
+func NewUDPHandler(host string, port int, password, cipher string, timeout time.Duration) core.UDPConnHandler {
+	client, err := shadowsocks.NewClient(host, port, password, cipher)
+	if err != nil {
+		return nil
+	}
+	return &udpHandler{
+		client:  client,
+		timeout: timeout,
+		conns:   make(map[core.UDPConn]net.PacketConn, 8),
+	}
+}
+
+func (h *udpHandler) Connect(conn core.UDPConn, target *net.UDPAddr) error {
+	proxyConn, err := h.client.ListenUDP(nil)
+	if err != nil {
+		return err
+	}
+	h.Lock()
+	h.conns[conn] = proxyConn
+	h.Unlock()
+	go h.processDownstreamUDP(conn, proxyConn)
+	return nil
+}
+
+func (h *udpHandler) processDownstreamUDP(conn core.UDPConn, proxyConn net.PacketConn) {
+	buf := core.NewBytes(core.BufSize)
+	defer func() {
+		h.Close(conn)
+		core.FreeBytes(buf)
+	}()
+	for {
+		proxyConn.SetDeadline(time.Now().Add(h.timeout))
+		n, addr, err := proxyConn.ReadFrom(buf)
+		if err != nil {
+			return
+		}
+		// No resolution will take place, the address sent by the proxy is a resolved IP.
+		udpAddr, err := net.ResolveUDPAddr("udp", addr.String())
+		if err != nil {
+			return
+		}
+		_, err = conn.WriteFrom(buf[:n], udpAddr)
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (h *udpHandler) ReceiveTo(conn core.UDPConn, data []byte, addr *net.UDPAddr) error {
+	h.Lock()
+	proxyConn, ok := h.conns[conn]
+	h.Unlock()
+	if !ok {
+		return fmt.Errorf("connection %v->%v does not exists", conn.LocalAddr(), addr)
+	}
+	_, err := proxyConn.WriteTo(data, addr)
+	return err
+}
+
+func (h *udpHandler) Close(conn core.UDPConn) {
+	conn.Close()
+	h.Lock()
+	defer h.Unlock()
+	if proxyConn, ok := h.conns[conn]; ok {
+		proxyConn.Close()
+	}
+}

--- a/shadowsocks/udp.go
+++ b/shadowsocks/udp.go
@@ -80,6 +80,7 @@ func (h *udpHandler) ReceiveTo(conn core.UDPConn, data []byte, addr *net.UDPAddr
 	if !ok {
 		return fmt.Errorf("connection %v->%v does not exist", conn.LocalAddr(), addr)
 	}
+	proxyConn.SetDeadline(time.Now().Add(h.timeout))
 	_, err := proxyConn.WriteTo(data, addr)
 	return err
 }

--- a/tunnel/outline.go
+++ b/tunnel/outline.go
@@ -31,10 +31,10 @@ import (
 type OutlineTunnel interface {
 	Tunnel
 
-	// NetworkConnectivityChanged should be called by the native platform when there has been a
-	// network connectivity change. `isConnected` indicates whether the network is connected.
+	// UpdateUDPSupport determines if UDP is supported following a network connectivity change.
+	// Sets the tunnel's UDP connection handler accordingly, falling back to DNS over TCP if UDP is not supported.
 	// Returns whether UDP proxying is supported in the new network.
-	NetworkConnectivityChanged(isConnected bool) bool
+	UpdateUDPSupport() bool
 }
 
 type outlinetunnel struct {
@@ -71,10 +71,7 @@ func NewOutlineTunnel(host string, port int, password, cipher string, isUDPEnabl
 	return t, nil
 }
 
-func (t *outlinetunnel) NetworkConnectivityChanged(isConnected bool) bool {
-	if !isConnected {
-		return false // Don't react to lost network connectivity.
-	}
+func (t *outlinetunnel) UpdateUDPSupport() bool {
 	client, err := shadowsocks.NewClient(t.host, t.port, t.password, t.cipher)
 	if err != nil {
 		return false

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -46,7 +46,6 @@ func (t *tunnel) Disconnect() {
 		return
 	}
 	t.isConnected = false
-	t.tunWriter.Close()
 	t.lwipStack.Close()
 }
 


### PR DESCRIPTION
* Implements (go-tun2socks) Shadowsocks connection handlers.
* Replaces Outline's SOCKS tunnel with a Shadowsocks tunnel.
* Updates the `OutlineTunnel` interface to support network connectivity change notifications.
* Fixes a TUN file descriptor ownership contract violation by not closing the TUN writer on tunnel disconnect, which in Android closes the underlying file descriptor.