### PR TITLE
Make DuplexConn a net.Conn

### DIFF
--- a/tunnel/intra/direct_split.go
+++ b/tunnel/intra/direct_split.go
@@ -6,51 +6,38 @@ import (
 )
 
 type splitter struct {
-	DuplexConn
-	conn *net.TCPConn
+	*net.TCPConn
 	used bool // Initially false.  Becomes true after the first write.
 }
 
 // DialWithSplit returns a TCP connection that always splits the initial upstream segment.
 // Like net.Conn, it is intended for two-threaded use, with one thread calling
 // Read and CloseRead, and another calling Write, ReadFrom, and CloseWrite.
-func DialWithSplit(network string, addr *net.TCPAddr) (DuplexConn, error) {
-	conn, err := net.DialTCP(network, nil, addr)
+func DialWithSplit(addr *net.TCPAddr) (DuplexConn, error) {
+	conn, err := net.DialTCP(addr.Network(), nil, addr)
 	if err != nil {
 		return nil, err
 	}
 
-	r := &retrier{
-		conn: conn,
-	}
-
-	return r, nil
-}
-
-// Read-related functions.
-func (s *splitter) Read(buf []byte) (int, error) {
-	return s.conn.Read(buf)
-}
-
-func (s *splitter) CloseRead() error {
-	return s.conn.CloseRead()
+	return &splitter{TCPConn: conn}, nil
 }
 
 // Write-related functions
 func (s *splitter) Write(b []byte) (int, error) {
+	conn := s.TCPConn
 	if s.used {
 		// After the first write, there is no special write behavior.
-		return s.conn.Write(b)
+		return conn.Write(b)
 	}
 
 	// Setting `used` to true ensures that this code only runs once per socket.
 	s.used = true
 	b1, b2 := splitHello(b)
-	n1, err := s.conn.Write(b1)
+	n1, err := conn.Write(b1)
 	if err != nil {
 		return n1, err
 	}
-	n2, err := s.conn.Write(b2)
+	n2, err := conn.Write(b2)
 	return n1 + n2, err
 }
 
@@ -65,11 +52,7 @@ func (s *splitter) ReadFrom(reader io.Reader) (bytes int64, err error) {
 	}
 
 	var b int64
-	b, err = s.conn.ReadFrom(reader)
+	b, err = s.TCPConn.ReadFrom(reader)
 	bytes += b
 	return
-}
-
-func (s *splitter) CloseWrite() error {
-	return s.conn.CloseWrite()
 }

--- a/tunnel/intra/retrier.go
+++ b/tunnel/intra/retrier.go
@@ -31,6 +31,10 @@ type retrier struct {
 	// conn is the current underlying connection.  It is only modified by the reader
 	// thread, so the reader functions may access it without acquiring a lock.
 	conn *net.TCPConn
+	// External read and write deadlines.  These need to be stored here so that
+	// they can be re-applied in the event of a retry.
+	readDeadline  time.Time
+	writeDeadline time.Time
 	// Time to wait between the first write and the first read before triggering a
 	// retry.
 	timeout time.Duration
@@ -88,22 +92,26 @@ func timeout(before, after time.Time) time.Duration {
 	return 1200*time.Millisecond + 2*rtt
 }
 
+// DefaultTimeout is the value that will cause DialWithSplitRetry to use the system's
+// default TCP timeout (typically 2-3 minutes).
+const DefaultTimeout time.Duration = 0
+
 // DialWithSplitRetry returns a TCP connection that transparently retries by
 // splitting the initial upstream segment if the socket closes without receiving a
 // reply.  Like net.Conn, it is intended for two-threaded use, with one thread calling
 // Read and CloseRead, and another calling Write, ReadFrom, and CloseWrite.
-func DialWithSplitRetry(network string, addr *net.TCPAddr, summary *TCPSocketSummary) (DuplexConn, error) {
+// synackTimeout controls how long to wait for the TCP handshake to complete.
+func DialWithSplitRetry(addr *net.TCPAddr, synackTimeout time.Duration, summary *TCPSocketSummary) (DuplexConn, error) {
 	before := time.Now()
-	conn, err := net.DialTCP(network, nil, addr)
+	conn, err := (&net.Dialer{Timeout: synackTimeout}).Dial(addr.Network(), addr.String())
 	if err != nil {
 		return nil, err
 	}
 	after := time.Now()
 
 	r := &retrier{
-		network:           network,
 		addr:              addr,
-		conn:              conn,
+		conn:              conn.(*net.TCPConn),
 		timeout:           timeout(before, after),
 		retryCompleteFlag: make(chan struct{}),
 		readCloseFlag:     make(chan struct{}),
@@ -143,14 +151,16 @@ func (r *retrier) Read(buf []byte) (n int, err error) {
 func (r *retrier) retry(buf []byte) (n int, err error) {
 	r.conn.Close()
 	var newConn *net.TCPConn
-	if newConn, err = net.DialTCP(r.network, nil, r.addr); err != nil {
+	if newConn, err = net.DialTCP(r.addr.Network(), nil, r.addr); err != nil {
 		return
 	}
 	r.conn = newConn
 	first, second := splitHello(r.hello)
 	r.stats.Split = int16(len(first))
 	// Set Retry to a non-nil value, indicating that a retry occurred.
-	r.summary.Retry = &r.stats
+	if r.summary != nil {
+		r.summary.Retry = &r.stats
+	}
 	if _, err = r.conn.Write(first); err != nil {
 		return
 	}
@@ -167,6 +177,9 @@ func (r *retrier) retry(buf []byte) (n int, err error) {
 	if r.writeClosed() {
 		r.conn.CloseWrite()
 	}
+	// The caller might have set read or write deadlines before the retry.
+	r.conn.SetReadDeadline(r.readDeadline)
+	r.conn.SetWriteDeadline(r.writeDeadline)
 	return r.conn.Read(buf)
 }
 
@@ -274,4 +287,53 @@ func (r *retrier) CloseWrite() error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 	return r.conn.CloseWrite()
+}
+
+func (r *retrier) Close() error {
+	if err := r.CloseWrite(); err != nil {
+		return err
+	}
+	return r.CloseRead()
+}
+
+// LocalAddr behaves slightly strangely: its value may change as a
+// result of a retry.  However, LocalAddr is largely useless for
+// TCP client sockets anyway, so nothing should be relying on this.
+func (r *retrier) LocalAddr() net.Addr {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.conn.LocalAddr()
+}
+
+func (r *retrier) RemoteAddr() net.Addr {
+	return r.addr
+}
+
+func (r *retrier) SetReadDeadline(t time.Time) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.readDeadline = t
+	// Don't enforce read deadlines until after the retry
+	// is complete.  Retry relies on setting its own read
+	// deadline, and we don't want this to interfere.
+	if r.retryCompleted() {
+		return r.conn.SetReadDeadline(t)
+	}
+	return nil
+}
+
+func (r *retrier) SetWriteDeadline(t time.Time) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.writeDeadline = t
+	return r.conn.SetWriteDeadline(t)
+}
+
+func (r *retrier) SetDeadline(t time.Time) error {
+	e1 := r.SetReadDeadline(t)
+	e2 := r.SetWriteDeadline(t)
+	if e1 != nil {
+		return e1
+	}
+	return e2
 }

--- a/tunnel/intra/retrier_test.go
+++ b/tunnel/intra/retrier_test.go
@@ -32,7 +32,7 @@ func makeSetup(t *testing.T) *setup {
 		t.Error("Server isn't TCP?")
 	}
 	var summary TCPSocketSummary
-	clientSide, err := DialWithSplitRetry("tcp", serverAddr, &summary)
+	clientSide, err := DialWithSplitRetry(serverAddr, DefaultTimeout, &summary)
 	if err != nil {
 		t.Error(err)
 	}

--- a/tunnel/intra/tcp.go
+++ b/tunnel/intra/tcp.go
@@ -46,8 +46,9 @@ type TCPListener interface {
 	OnTCPSocketClosed(*TCPSocketSummary)
 }
 
+// DuplexConn represents a bidirectional stream socket.
 type DuplexConn interface {
-	io.ReadWriter
+	net.Conn
 	io.ReaderFrom
 	CloseWrite() error
 	CloseRead() error
@@ -123,9 +124,9 @@ func (h *tcpHandler) Handle(conn net.Conn, target *net.TCPAddr) error {
 	var err error
 	if summary.ServerPort == 443 {
 		if h.alwaysSplitHTTPS {
-			c, err = DialWithSplit(target.Network(), target)
+			c, err = DialWithSplit(target)
 		} else {
-			c, err = DialWithSplitRetry(target.Network(), target, &summary)
+			c, err = DialWithSplitRetry(target, DefaultTimeout, &summary)
 		}
 	} else {
 		c, err = net.DialTCP(target.Network(), nil, target)


### PR DESCRIPTION
This is a prerequisite for DoH to use the retrier.

This change also adds a configurable TCP handshake
timeout to retrier, and simplifies the direct split code.