### PR TITLE
Add DOH to the Intra tunnel constructor

### DIFF
--- a/intra/intra.go
+++ b/intra/intra.go
@@ -40,12 +40,12 @@ func init() {
 //
 // Throws an exception if the TUN file descriptor cannot be opened, or if the tunnel fails to
 // connect.
-func ConnectIntraTunnel(fd int, fakedns, udpdns, tcpdns string, alwaysSplitHTTPS bool, listener tunnel.IntraListener) (tunnel.IntraTunnel, error) {
+func ConnectIntraTunnel(fd int, fakedns, udpdns, tcpdns string, dohdns doh.Transport, listener tunnel.IntraListener) (tunnel.IntraTunnel, error) {
 	tun, err := tunnel.MakeTunFile(fd)
 	if err != nil {
 		return nil, err
 	}
-	t, err := tunnel.NewIntraTunnel(fakedns, udpdns, tcpdns, tun, alwaysSplitHTTPS, listener)
+	t, err := tunnel.NewIntraTunnel(fakedns, udpdns, tcpdns, dohdns, tun, listener)
 	if err != nil {
 		return nil, err
 	}

--- a/tunnel/intra/tcp.go
+++ b/tunnel/intra/tcp.go
@@ -28,10 +28,11 @@ import (
 	"github.com/Jigsaw-Code/outline-go-tun2socks/tunnel/intra/split"
 )
 
-// TCPHandler is a core TCP handler that also supports DOH.
+// TCPHandler is a core TCP handler that also supports DOH and splitting control.
 type TCPHandler interface {
 	core.TCPConnHandler
 	SetDNS(doh.Transport)
+	SetAlwaysSplitHTTPS(bool)
 }
 
 type tcpHandler struct {
@@ -63,12 +64,11 @@ type TCPListener interface {
 // Currently this class only redirects DNS traffic to a
 // specified server.  (This should be rare for TCP.)
 // All other traffic is forwarded unmodified.
-func NewTCPHandler(fakedns, truedns net.TCPAddr, alwaysSplitHTTPS bool, listener TCPListener) TCPHandler {
+func NewTCPHandler(fakedns, truedns net.TCPAddr, listener TCPListener) TCPHandler {
 	return &tcpHandler{
-		fakedns:          fakedns,
-		truedns:          truedns,
-		alwaysSplitHTTPS: alwaysSplitHTTPS,
-		listener:         listener,
+		fakedns:  fakedns,
+		truedns:  truedns,
+		listener: listener,
 	}
 }
 
@@ -154,4 +154,8 @@ func (h *tcpHandler) Handle(conn net.Conn, target *net.TCPAddr) error {
 
 func (h *tcpHandler) SetDNS(dns doh.Transport) {
 	h.dns.Store(dns)
+}
+
+func (h *tcpHandler) SetAlwaysSplitHTTPS(s bool) {
+	h.alwaysSplitHTTPS = s
 }


### PR DESCRIPTION
We need DOH in the constructor to ensure correct handling
of the initial packets that are read from the tun device.

This change also enables asynchronous control of `alwaysSplitHTTPS`,
which is preferable because it may take several seconds to
determine whether this setting should be enabled.