### PR TITLE
Drop server IPs and sockets that aren't working

### DIFF
--- a/tunnel/intra/doh/doh.go
+++ b/tunnel/intra/doh/doh.go
@@ -204,10 +204,9 @@ func (t *transport) doQuery(q []byte) (response []byte, server *net.TCPAddr, qer
 		qerr = &queryError{BadQuery, fmt.Errorf("Query length is %d", len(q))}
 		return
 	}
-	id0, id1 := q[0], q[1]
-	id := int(id0)*256 + int(id1)
 	// Zero out the query ID.
-	q[0], q[1] = 0, 0
+	id := binary.BigEndian.Uint16(q)
+	binary.BigEndian.PutUint16(q, 0)
 	req, err := http.NewRequest(http.MethodPost, t.url, bytes.NewBuffer(q))
 	if err != nil {
 		qerr = &queryError{InternalError, err}
@@ -328,9 +327,9 @@ func (t *transport) doQuery(q []byte) (response []byte, server *net.TCPAddr, qer
 		return
 	}
 	// Restore the query ID.
-	q[0], q[1] = id0, id1
+	binary.BigEndian.PutUint16(q, id)
 	if len(response) >= 2 {
-		response[0], response[1] = id0, id1
+		binary.BigEndian.PutUint16(response, id)
 	} else {
 		qerr = &queryError{BadResponse, fmt.Errorf("Response length is %d", len(response))}
 		return

--- a/tunnel/intra/doh/doh.go
+++ b/tunnel/intra/doh/doh.go
@@ -16,6 +16,7 @@ package doh
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -25,6 +26,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptrace"
+	"net/textproto"
 	"net/url"
 	"strconv"
 	"time"
@@ -77,6 +79,7 @@ type Transport interface {
 type transport struct {
 	Transport
 	url      string
+	hostname string
 	port     int
 	ips      ipmap.IPMap
 	client   http.Client
@@ -154,22 +157,25 @@ func NewTransport(rawurl string, addrs []string, listener Listener) (Transport, 
 	}
 	t := &transport{
 		url:      rawurl,
+		hostname: parsedurl.Hostname(),
 		port:     port,
 		listener: listener,
 		ips:      ipmap.NewIPMap(),
 	}
-	ips := t.ips.Get(parsedurl.Hostname())
+	ips := t.ips.Get(t.hostname)
 	for _, addr := range addrs {
 		ips.Add(addr)
 	}
 	if ips.Empty() {
-		return nil, fmt.Errorf("No IP addresses for %s", parsedurl.Hostname())
+		return nil, fmt.Errorf("No IP addresses for %s", t.hostname)
 	}
 
 	// Override the dial function.
 	t.client.Transport = &http.Transport{
-		Dial:              t.dial,
-		ForceAttemptHTTP2: true,
+		Dial:                  t.dial,
+		ForceAttemptHTTP2:     true,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 20 * time.Second, // Same value as Android DNS-over-TLS
 	}
 	return t, nil
 }
@@ -190,34 +196,101 @@ func (e *queryError) Unwrap() error {
 // Given a raw DNS query (including the query ID), this function sends the
 // query.  If the query is successful, it returns the response and a nil qerr.  Otherwise,
 // it returns a nil response and a qerr with a status value indicating the cause.
-// Independent of the query's success or failure, this function also returns the IP
-// address of the server on a best-effort basis, returning the empty string if the address
-// could not be determined.
-func (t *transport) doQuery(q []byte) (response []byte, server string, qerr error) {
+// Independent of the query's success or failure, this function also returns the
+// address of the server on a best-effort basis, or nil if the address could not
+// be determined.
+func (t *transport) doQuery(q []byte) (response []byte, server *net.TCPAddr, qerr error) {
 	if len(q) < 2 {
 		qerr = &queryError{BadQuery, fmt.Errorf("Query length is %d", len(q))}
 		return
 	}
 	id0, id1 := q[0], q[1]
+	id := int(id0)*256 + int(id1)
 	// Zero out the query ID.
 	q[0], q[1] = 0, 0
-	req, err := http.NewRequest("POST", t.url, bytes.NewBuffer(q))
+	req, err := http.NewRequest(http.MethodPost, t.url, bytes.NewBuffer(q))
 	if err != nil {
 		qerr = &queryError{InternalError, err}
 		return
 	}
 
+	hostname := t.hostname
+
+	// The connection used for this request.  If the request fails, we will close
+	// this socket, in case it is no longer functioning.
+	var conn net.Conn
+
+	// Error cleanup function.  If the query fails, this function will close the
+	// underlying socket and disconfirm the server IP.  Empirically, sockets often
+	// become unresponsive after a network change, causing timeouts on all requests.
+	defer func() {
+		if qerr == nil {
+			return
+		}
+		log.Infof("%d Query failed: %v", id, qerr)
+		if server != nil {
+			log.Debugf("%d Disconfirming %s", id, server.IP.String())
+			t.ips.Get(hostname).Disconfirm(server.IP)
+		}
+		if conn != nil {
+			log.Infof("%d Closing failing DoH socket", id)
+			conn.Close()
+		}
+	}()
+
 	// Add a trace to the request in order to expose the server's IP address.
-	// If GotConn is called, it will always be before the request completes or fails,
-	// and therefore before doQuery returns.
+	// Only GotConn performs any action; the other methods just provide debug logs.
+	// GotConn runs before client.Do() returns, so there is no data race when
+	// reading the variables it has set.
 	trace := httptrace.ClientTrace{
+		GetConn: func(hostPort string) {
+			log.Debugf("%d GetConn(%s)", id, hostPort)
+		},
 		GotConn: func(info httptrace.GotConnInfo) {
+			log.Debugf("%d GotConn(%v)", id, info)
 			if info.Conn == nil {
 				return
 			}
-			if addr := info.Conn.RemoteAddr(); addr != nil {
-				server, _, _ = net.SplitHostPort(addr.String())
-			}
+			conn = info.Conn
+			// info.Conn is a DuplexConn, so RemoteAddr is actually a TCPAddr.
+			server = conn.RemoteAddr().(*net.TCPAddr)
+		},
+		PutIdleConn: func(err error) {
+			log.Debugf("%d PutIdleConn(%v)", id, err)
+		},
+		GotFirstResponseByte: func() {
+			log.Debugf("%d GotFirstResponseByte()", id)
+		},
+		Got100Continue: func() {
+			log.Debugf("%d Got100Continue()", id)
+		},
+		Got1xxResponse: func(code int, header textproto.MIMEHeader) error {
+			log.Debugf("%d Got1xxResponse(%d, %v)", id, code, header)
+			return nil
+		},
+		DNSStart: func(info httptrace.DNSStartInfo) {
+			log.Debugf("%d DNSStart(%v)", id, info)
+		},
+		DNSDone: func(info httptrace.DNSDoneInfo) {
+			log.Debugf("%d, DNSDone(%v)", id, info)
+		},
+		ConnectStart: func(network, addr string) {
+			log.Debugf("%d ConnectStart(%s, %s)", id, network, addr)
+		},
+		ConnectDone: func(network, addr string, err error) {
+			log.Debugf("%d ConnectDone(%s, %s, %v)", id, network, addr, err)
+		},
+		TLSHandshakeStart: func() {
+			log.Debugf("%d TLSHandshakeStart()", id)
+		},
+		TLSHandshakeDone: func(state tls.ConnectionState, err error) {
+			log.Debugf("%d TLSHandshakeDone(%v, %v)", id, state, err)
+		},
+		WroteHeaders: func() {
+			log.Debugf("%d WroteHeaders()", id)
+		},
+		WroteRequest: func(info httptrace.WroteRequestInfo) {
+			log.Debugf("%d WroteRequest(%v)", id, info)
 		},
 	}
 	req = req.WithContext(httptrace.WithClientTrace(req.Context(), &trace))
@@ -226,20 +299,32 @@ func (t *transport) doQuery(q []byte) (response []byte, server string, qerr erro
 	req.Header.Set("Content-Type", mimetype)
 	req.Header.Set("Accept", mimetype)
 	req.Header.Set("User-Agent", "Intra")
+	log.Debugf("%d Sending query", id)
 	httpResponse, err := t.client.Do(req)
 	if err != nil {
 		qerr = &queryError{SendFailed, err}
 		return
 	}
-	if httpResponse.StatusCode != http.StatusOK {
-		err := fmt.Errorf("HTTP request failed: %d", httpResponse.StatusCode)
-		qerr = &queryError{HTTPError, err}
-		return
-	}
+	log.Debugf("%d Got response", id)
 	response, err = ioutil.ReadAll(httpResponse.Body)
-	httpResponse.Body.Close()
 	if err != nil {
 		qerr = &queryError{BadResponse, err}
+		return
+	}
+	httpResponse.Body.Close()
+	log.Debugf("%d Closed response", id)
+
+	// Update the hostname, which could have changed due to a redirect.
+	hostname = httpResponse.Request.URL.Hostname()
+
+	if httpResponse.StatusCode != http.StatusOK {
+		err := fmt.Errorf("HTTP request failed: %d", httpResponse.StatusCode)
+		reqBuf := new(bytes.Buffer)
+		req.Write(reqBuf)
+		respBuf := new(bytes.Buffer)
+		httpResponse.Write(respBuf)
+		log.Debugf("%d request: %s\nresponse: %s", id, reqBuf.String(), respBuf.String())
+		qerr = &queryError{HTTPError, err}
 		return
 	}
 	// Restore the query ID.
@@ -250,8 +335,10 @@ func (t *transport) doQuery(q []byte) (response []byte, server string, qerr erro
 		qerr = &queryError{BadResponse, fmt.Errorf("Response length is %d", len(response))}
 		return
 	}
-	// Record a working IP address for this server
-	t.ips.Get(httpResponse.Request.URL.Hostname()).Confirm(server)
+	if server != nil {
+		// Record a working IP address for this server
+		t.ips.Get(hostname).Confirm(server.IP)
+	}
 	return
 }
 
@@ -266,11 +353,15 @@ func (t *transport) Query(q []byte) ([]byte, error) {
 		if errors.As(err, &qerr) {
 			status = qerr.status
 		}
+		var ip string
+		if server != nil {
+			ip = server.IP.String()
+		}
 		t.listener.OnTransaction(&Summary{
 			Latency:  latency.Seconds(),
 			Query:    q,
 			Response: response,
-			Server:   server,
+			Server:   ip,
 			Status:   status,
 		})
 	}

--- a/tunnel/intra/doh/ipmap/ipmap.go
+++ b/tunnel/intra/doh/ipmap/ipmap.go
@@ -127,13 +127,8 @@ func (s *IPSet) Confirmed() net.IP {
 	return s.confirmed
 }
 
-// Confirm marks ipstr as the confirmed address, if it is a valid IP address.
-func (s *IPSet) Confirm(ipstr string) {
-	ip := net.ParseIP(ipstr)
-	if ip == nil {
-		// Ignore invalid IP address.
-		return
-	}
+// Confirm marks ip as the confirmed address.
+func (s *IPSet) Confirm(ip net.IP) {
 	// Optimization: Skip setting if it hasn't changed.
 	if ip.Equal(s.Confirmed()) {
 		// This is the common case.

--- a/tunnel/intra/doh/ipmap/ipmap_test.go
+++ b/tunnel/intra/doh/ipmap/ipmap_test.go
@@ -105,7 +105,7 @@ func TestConfirmed(t *testing.T) {
 	}
 
 	ips := s.GetAll()
-	s.Confirm(ips[0].String())
+	s.Confirm(ips[0])
 	if !ips[0].Equal(s.Confirmed()) {
 		t.Error("Confirmation failed")
 	}
@@ -121,7 +121,7 @@ func TestConfirmNew(t *testing.T) {
 	s := m.Get("example")
 	s.Add("192.0.2.1")
 	// Confirm a new address.
-	s.Confirm("192.0.2.2")
+	s.Confirm(net.ParseIP("192.0.2.2"))
 	if s.Confirmed() == nil || s.Confirmed().String() != "192.0.2.2" {
 		t.Error("Confirmation failed")
 	}
@@ -135,7 +135,7 @@ func TestDisconfirmMismatch(t *testing.T) {
 	m := NewIPMap()
 	s := m.Get("www.google.com")
 	ips := s.GetAll()
-	s.Confirm(ips[0].String())
+	s.Confirm(ips[0])
 
 	// Make a copy
 	otherIP := net.ParseIP(ips[0].String())


### PR DESCRIPTION
With this change, server IPs will be disconfirmed if
they are reachable but not correctly functioning,
and sockets will be closed if they start reporting
errors.

This change also adds significantly more debug logging,
which is not enabled in the default build.