### PR TITLE
Update fakeListener to support new Listener interface

### DIFF
--- a/tunnel/intra/doh/doh_test.go
+++ b/tunnel/intra/doh/doh_test.go
@@ -286,8 +286,13 @@ type fakeListener struct {
 	summary *Summary
 }
 
-func (l *fakeListener) OnTransaction(s *Summary) {
-	l.summary = s
+func (l *fakeListener) OnQuery(url string) Token {
+	var tok Token
+	return tok
+}
+
+func (l *fakeListener) OnResponse(tok Token, summ *Summary) {
+	l.summary = summ
 }
 
 type fakeConn struct {

--- a/tunnel/intra/doh/doh_test.go
+++ b/tunnel/intra/doh/doh_test.go
@@ -287,8 +287,7 @@ type fakeListener struct {
 }
 
 func (l *fakeListener) OnQuery(url string) Token {
-	var tok Token
-	return tok
+	return nil
 }
 
 func (l *fakeListener) OnResponse(tok Token, summ *Summary) {


### PR DESCRIPTION
2d8ca51e12d950199239a6afe5f6f45daf27bf62 changed the Listener interface by removing `OnTransaction` and adding `OnQuery` and `OnResponse`, but it looks like the `fakeListener` implementation got left behind.