### PR TITLE
Use valid DNS queries in doh_test.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/songgao/water v0.0.0-20190725173103-fd331bda3f4b // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
-	golang.org/x/net v0.0.0-20190909003024-a7b16738d86b // indirect
+	golang.org/x/net v0.0.0-20190909003024-a7b16738d86b
 	golang.org/x/sys v0.0.0-20191024073052-e66fe6eb8e0c // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )


### PR DESCRIPTION
I started using net.dns.dnsmessage in doh.go to parse the request, with the intent of adding a parse-transform-serialize function to add padding. But I found the parse step failed because the test queries didn't have a valid questions section!

The issue is that {1, 2, 3, 4, 5} encodes a message that claims to have 5 questions, but actually contains zero! (See [RFC1035](https://tools.ietf.org/html/rfc1035) section 4.1.1.)

