### PR TITLE
Accept nil dialer in doh.NewTransport

### DIFF
--- a/tunnel/intra/doh/doh.go
+++ b/tunnel/intra/doh/doh.go
@@ -147,6 +147,9 @@ func (t *transport) dial(network, addr string) (net.Conn, error) {
 //   timeout but will not mutate it otherwise.
 // `listener` will receive the status of each DNS query when it is complete.
 func NewTransport(rawurl string, addrs []string, dialer *net.Dialer, listener Listener) (Transport, error) {
+	if dialer == nil {
+		dialer = &net.Dialer{}
+	}
 	parsedurl, err := url.Parse(rawurl)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The tests use this behavior for the sake of compactness.