### PR TITLE
Improve protection of DNS queries

### DIFF
--- a/tunnel/intra/doh/ipmap/ipmap.go
+++ b/tunnel/intra/doh/ipmap/ipmap.go
@@ -104,7 +104,7 @@ func (s *IPSet) Add(hostname string) {
 	// Don't hold the ipMap lock during blocking I/O.
 	resolved, err := s.r.LookupIPAddr(context.TODO(), hostname)
 	if err != nil {
-		log.Infof("Error resolving %s: %v", hostname, err)
+		log.Warnf("Failed to resolve %s: %v", hostname, err)
 	}
 	s.Lock()
 	for _, addr := range resolved {

--- a/tunnel/intra/doh/ipmap/ipmap.go
+++ b/tunnel/intra/doh/ipmap/ipmap.go
@@ -19,6 +19,8 @@ import (
 	"math/rand"
 	"net"
 	"sync"
+
+	"github.com/eycorsican/go-tun2socks/common/log"
 )
 
 // IPMap maps hostnames to IPSets.
@@ -74,8 +76,8 @@ func (m *ipMap) Get(hostname string) *IPSet {
 // One IP can be marked as confirmed to be working correctly.
 type IPSet struct {
 	sync.RWMutex
-	ips       []net.IP // All known IPs for the server.
-	confirmed net.IP   // IP address confirmed to be working
+	ips       []net.IP      // All known IPs for the server.
+	confirmed net.IP        // IP address confirmed to be working
 	r         *net.Resolver // Resolver to use for hostname resolution
 }
 
@@ -100,7 +102,10 @@ func (s *IPSet) add(ip net.IP) {
 // The hostname can be a domain name or an IP address.
 func (s *IPSet) Add(hostname string) {
 	// Don't hold the ipMap lock during blocking I/O.
-	resolved, _ := s.r.LookupIPAddr(context.TODO(), hostname)
+	resolved, err := s.r.LookupIPAddr(context.TODO(), hostname)
+	if err != nil {
+		log.Infof("Error resolving %s: %v", hostname, err)
+	}
 	s.Lock()
 	for _, addr := range resolved {
 		s.add(addr.IP)

--- a/tunnel/intra/protect/protect.go
+++ b/tunnel/intra/protect/protect.go
@@ -15,18 +15,29 @@
 package protect
 
 import (
+	"context"
+	"errors"
 	"net"
+	"strings"
 	"syscall"
 )
 
-// Protector is a wrapper for Android's VpnService.protect().
+// Protector provides the ability to bypass a VPN on Android, pre-Lollipop.
 type Protector interface {
 	// Protect a socket, i.e. exclude it from the VPN.
 	// This is needed in order to avoid routing loops for the VPN's own sockets.
+	// This is a wrapper for Android's VpnService.protect().
 	Protect(socket int32) bool
+
+	// Returns a comma-separated list of the system's configured DNS resolvers,
+	// in roughly descending priority order.
+	// This is needed because (1) Android Java cannot protect DNS lookups but Go can, and
+	// (2) Android Java can determine the list of system DNS resolvers but Go cannot.
+	// A comma-separated list is used because Gomobile cannot bind []string.
+	GetResolvers() string
 }
 
-func makeControl(p Protector) (func(string, string, syscall.RawConn) error) {
+func makeControl(p Protector) func(string, string, syscall.RawConn) error {
 	return func(network, address string, c syscall.RawConn) error {
 		return c.Control(func(fd uintptr) {
 			if !p.Protect(int32(fd)) {
@@ -34,6 +45,34 @@ func makeControl(p Protector) (func(string, string, syscall.RawConn) error) {
 			}
 		})
 	}
+}
+
+// Returns the first IP address that is of the specified length (i.e. family).
+func scan(ips []string, l int) string {
+	for _, ip := range ips {
+		if len(net.ParseIP(ip)) == l {
+			return ip
+		}
+	}
+	return ""
+}
+
+// Given a slice of IP addresses, and a transport address, return a transport
+// address with the IP replaced by the first IP of the same family in `ips`, or
+// by the first address of a different family if there are none of the same.
+func replaceIP(addr string, ips []string) (string, error) {
+	if len(ips) == 0 {
+		return "", errors.New("No resolvers available")
+	}
+	orighost, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", err
+	}
+	newIP := scan(ips, len(net.ParseIP(orighost)))
+	if newIP == "" {
+		newIP = ips[0]
+	}
+	return net.JoinHostPort(newIP, port), nil
 }
 
 // MakeDialer creates a new Dialer.  Recipients can safely mutate
@@ -45,9 +84,17 @@ func MakeDialer(p Protector) *net.Dialer {
 	d := &net.Dialer{
 		Control: makeControl(p),
 	}
+	resolverDialer := func(ctx context.Context, network, address string) (net.Conn, error) {
+		resolvers := strings.Split(p.GetResolvers(), ",")
+		newAddress, err := replaceIP(address, resolvers)
+		if err != nil {
+			return nil, err
+		}
+		return d.DialContext(ctx, network, newAddress)
+	}
 	d.Resolver = &net.Resolver{
 		PreferGo: true,
-		Dial: d.DialContext,
+		Dial:     resolverDialer,
 	}
 	return d
 }
@@ -58,7 +105,7 @@ func MakeListenConfig(p Protector) *net.ListenConfig {
 	if p == nil {
 		return &net.ListenConfig{}
 	}
-	return &net.ListenConfig {
+	return &net.ListenConfig{
 		Control: makeControl(p),
 	}
 }

--- a/tunnel/intra/protect/protect_test.go
+++ b/tunnel/intra/protect/protect_test.go
@@ -18,6 +18,10 @@ func (p *fakeProtector) Protect(fd int32) bool {
 	return true
 }
 
+func (p *fakeProtector) GetResolvers() string {
+	return "8.8.8.8,2001:4860:4860::8888"
+}
+
 // This interface serves as a supertype of net.TCPConn and net.UDPConn, so
 // that they can share the verifyMatch() function.
 type hasSyscallConn interface {


### PR DESCRIPTION
Go on Android cannot determine the system's preferred DNS servers.
This is normally fine, because Resolver.PreferGo defaults to false,
but we need to set PreferGo to true when protection is enabled,
in order to protect the DNS query's UDP socket.

This change requires a Protector to indicate the list of DNS
servers, so that the Resolver can create a protected socket to
one of those servers.