### PR TITLE
Don't panic if protect() returns false

### DIFF
--- a/tunnel/intra/protect/protect.go
+++ b/tunnel/intra/protect/protect.go
@@ -44,6 +44,7 @@ func makeControl(p Protector) func(string, string, syscall.RawConn) error {
 	return func(network, address string, c syscall.RawConn) error {
 		return c.Control(func(fd uintptr) {
 			if !p.Protect(int32(fd)) {
+				// TODO: Record and report these errors.
 				log.Errorf("Failed to protect a %s socket", network)
 			}
 		})

--- a/tunnel/intra/protect/protect.go
+++ b/tunnel/intra/protect/protect.go
@@ -21,6 +21,8 @@ import (
 	"net"
 	"strings"
 	"syscall"
+
+	"github.com/eycorsican/go-tun2socks/common/log"
 )
 
 // Protector provides the ability to bypass a VPN on Android, pre-Lollipop.
@@ -42,7 +44,7 @@ func makeControl(p Protector) func(string, string, syscall.RawConn) error {
 	return func(network, address string, c syscall.RawConn) error {
 		return c.Control(func(fd uintptr) {
 			if !p.Protect(int32(fd)) {
-				panic("Failed to protect socket")
+				log.Errorf("Failed to protect a %s socket", network)
 			}
 		})
 	}


### PR DESCRIPTION
This happens frequently on Kitkat (Android 4.4).
A panic might be appropriate if protect _always_ fails,
because the whole system will be nonfunctional, but
for sporadic or edge-case failures it's ok to log
the error and continue.