### PR TITLE
Close the TUN writer when shutting down the tunnel

### DIFF
--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -47,6 +47,7 @@ func (t *tunnel) Disconnect() {
 	}
 	t.isConnected = false
 	t.lwipStack.Close()
+	t.tunWriter.Close()
 }
 
 func (t *tunnel) Write(data []byte) (int, error) {


### PR DESCRIPTION
Otherwise, the TUN writer is only closed by the garbage collector, which
can cause a long delay.

See https://github.com/Jigsaw-Code/Intra/issues/285