### PR TITLE
Don't use os.NewFile to create the TUN writer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,6 @@ require (
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a // indirect
 	golang.org/x/mobile v0.0.0-20200329125638-4c31acba0007 // indirect
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73
-	golang.org/x/sys v0.0.0-20200909081042-eff7692f9009 // indirect
+	golang.org/x/sys v0.0.0-20200909081042-eff7692f9009
 	google.golang.org/protobuf v1.25.0 // indirect
 )

--- a/intra/intra.go
+++ b/intra/intra.go
@@ -45,17 +45,14 @@ func init() {
 // Throws an exception if the TUN file descriptor cannot be opened, or if the tunnel fails to
 // connect.
 func ConnectIntraTunnel(fd int, fakedns string, dohdns doh.Transport, protector protect.Protector, listener tunnel.IntraListener) (tunnel.IntraTunnel, error) {
-	tun, err := tunnel.MakeTunFile(fd)
-	if err != nil {
-		return nil, err
-	}
+	tun := tunnel.TUNFile(fd)
 	dialer := protect.MakeDialer(protector)
 	config := protect.MakeListenConfig(protector)
 	t, err := tunnel.NewIntraTunnel(fakedns, dohdns, tun, dialer, config, listener)
 	if err != nil {
 		return nil, err
 	}
-	go tunnel.ProcessInputPackets(t, tun)
+	go tunnel.ProcessInputPackets(t, tun, nil)
 	return t, nil
 }
 

--- a/intra/intra.go
+++ b/intra/intra.go
@@ -56,7 +56,7 @@ func ConnectIntraTunnel(fd int, fakedns string, dohdns doh.Transport, protector 
 	if err != nil {
 		return nil, err
 	}
-	go tunnel.ProcessInputPackets(t, tun, nil)
+	go tunnel.ProcessInputPackets(t, tun)
 	return t, nil
 }
 

--- a/intra/intra.go
+++ b/intra/intra.go
@@ -34,7 +34,9 @@ func init() {
 // rules.  Currently, this only consists of redirecting DNS packets to a specified
 // server; all other data flows directly to its destination.
 //
-// The caller retains ownership of `fd`.
+// `fd` is the TUN device.  The IntraTunnel acquires an additional reference to it, which
+//     is released by IntraTunnel.Disconnect(), so the caller must close `fd` _and_ call
+//     Disconnect() in order to close the TUN device.
 // `fakedns` is the DNS server that the system believes it is using, in "host:port" style.
 //   The port is normally 53.
 // `udpdns` and `tcpdns` are the location of the actual DNS server being used.  For DNS

--- a/intra/intra.go
+++ b/intra/intra.go
@@ -34,6 +34,7 @@ func init() {
 // rules.  Currently, this only consists of redirecting DNS packets to a specified
 // server; all other data flows directly to its destination.
 //
+// The caller retains ownership of `fd`.
 // `fakedns` is the DNS server that the system believes it is using, in "host:port" style.
 //   The port is normally 53.
 // `udpdns` and `tcpdns` are the location of the actual DNS server being used.  For DNS
@@ -45,7 +46,10 @@ func init() {
 // Throws an exception if the TUN file descriptor cannot be opened, or if the tunnel fails to
 // connect.
 func ConnectIntraTunnel(fd int, fakedns string, dohdns doh.Transport, protector protect.Protector, listener tunnel.IntraListener) (tunnel.IntraTunnel, error) {
-	tun := tunnel.TUNFile(fd)
+	tun, err := tunnel.MakeTunFile(fd)
+	if err != nil {
+		return nil, err
+	}
 	dialer := protect.MakeDialer(protector)
 	config := protect.MakeListenConfig(protector)
 	t, err := tunnel.NewIntraTunnel(fakedns, dohdns, tun, dialer, config, listener)

--- a/outline/android/tun2socks.go
+++ b/outline/android/tun2socks.go
@@ -38,7 +38,9 @@ type OutlineTunnel interface {
 // Returns an OutlineTunnel instance and does *not* take ownership of the TUN file descriptor; the
 // caller is responsible for closing after OutlineTunnel disconnects.
 //
-// `fd` is the file descriptor to the VPN TUN device. Must be set to blocking mode.
+// `fd` is the TUN device.  The OutlineTunnel acquires an additional reference to it, which
+//     is released by OutlineTunnel.Disconnect(), so the caller must close `fd` _and_ call
+//     Disconnect() in order to close the TUN device.
 // `host` is  IP address of the Shadowsocks proxy server.
 // `port` is the port of the Shadowsocks proxy server.
 // `password` is the password of the Shadowsocks proxy.

--- a/outline/android/tun2socks.go
+++ b/outline/android/tun2socks.go
@@ -59,6 +59,6 @@ func ConnectShadowsocksTunnel(fd int, host string, port int, password, cipher st
 	if err != nil {
 		return nil, err
 	}
-	go tunnel.ProcessInputPackets(t, tun, nil)
+	go tunnel.ProcessInputPackets(t, tun)
 	return t, nil
 }

--- a/outline/android/tun2socks.go
+++ b/outline/android/tun2socks.go
@@ -51,14 +51,11 @@ func ConnectShadowsocksTunnel(fd int, host string, port int, password, cipher st
 	if port <= 0 || port > math.MaxUint16 {
 		return nil, fmt.Errorf("Invalid port number: %v", port)
 	}
-	tun, err := tunnel.MakeTunFile(fd)
-	if err != nil {
-		return nil, err
-	}
+	tun := tunnel.TUNFile(fd)
 	t, err := tunnel.NewOutlineTunnel(host, port, password, cipher, isUDPEnabled, tun)
 	if err != nil {
 		return nil, err
 	}
-	go tunnel.ProcessInputPackets(t, tun)
+	go tunnel.ProcessInputPackets(t, tun, nil)
 	return t, nil
 }

--- a/outline/android/tun2socks.go
+++ b/outline/android/tun2socks.go
@@ -51,7 +51,10 @@ func ConnectShadowsocksTunnel(fd int, host string, port int, password, cipher st
 	if port <= 0 || port > math.MaxUint16 {
 		return nil, fmt.Errorf("Invalid port number: %v", port)
 	}
-	tun := tunnel.TUNFile(fd)
+	tun, err := tunnel.MakeTunFile(fd)
+	if err != nil {
+		return nil, err
+	}
 	t, err := tunnel.NewOutlineTunnel(host, port, password, cipher, isUDPEnabled, tun)
 	if err != nil {
 		return nil, err

--- a/outline/electron/main.go
+++ b/outline/electron/main.go
@@ -22,15 +22,20 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	oss "github.com/Jigsaw-Code/outline-go-tun2socks/outline/shadowsocks"
-	"github.com/Jigsaw-Code/outline-go-tun2socks/tunnel"
+	"github.com/Jigsaw-Code/outline-go-tun2socks/shadowsocks"
 	"github.com/eycorsican/go-tun2socks/common/log"
 	_ "github.com/eycorsican/go-tun2socks/common/log/simple" // Register a simple logger.
+	"github.com/eycorsican/go-tun2socks/core"
+	"github.com/eycorsican/go-tun2socks/proxy/dnsfallback"
 	"github.com/eycorsican/go-tun2socks/tun"
 )
 
 const (
+	mtu        = 1500
+	udpTimeout = 30 * time.Second
 	persistTun = true // Linux: persist the TUN interface after the last open file descriptor is closed.
 )
 
@@ -107,25 +112,37 @@ func main() {
 		log.Errorf("Failed to open TUN device: %v", err)
 		os.Exit(oss.SystemMisconfigured)
 	}
+	// Output packets to TUN device
+	core.RegisterOutputFn(tunDevice.Write)
 
-	t, err := tunnel.NewOutlineTunnel(*args.proxyHost, *args.proxyPort,
-		*args.proxyPassword, *args.proxyCipher, !*args.dnsFallback, tunDevice)
-	if err != nil {
-		log.Errorf("Failed to start tunnel")
-		os.Exit(oss.ShadowsocksStartFailure)
+	// Register TCP and UDP connection handlers
+	core.RegisterTCPConnHandler(
+		shadowsocks.NewTCPHandler(*args.proxyHost, *args.proxyPort, *args.proxyPassword, *args.proxyCipher))
+	if *args.dnsFallback {
+		// UDP connectivity not supported, fall back to DNS over TCP.
+		log.Debugf("Registering DNS fallback UDP handler")
+		core.RegisterUDPConnHandler(dnsfallback.NewUDPHandler())
+	} else {
+		core.RegisterUDPConnHandler(
+			shadowsocks.NewUDPHandler(*args.proxyHost, *args.proxyPort, *args.proxyPassword, *args.proxyCipher, udpTimeout))
 	}
 
-	go tunnel.ProcessInputPackets(t, tunDevice, func(err error) {
-		log.Errorf("Error while processing input: %v", err)
-		os.Exit(oss.Unexpected)
-	})
+	// Configure LWIP stack to receive input data from the TUN device
+	lwipWriter := core.NewLWIPStack()
+	go func() {
+		_, err := io.CopyBuffer(lwipWriter, tunDevice, make([]byte, mtu))
+		if err != nil {
+			log.Errorf("Failed to write data to network stack: %v", err)
+			os.Exit(oss.Unexpected)
+		}
+	}()
+
 	log.Infof("tun2socks running...")
 
 	osSignals := make(chan os.Signal, 1)
 	signal.Notify(osSignals, os.Interrupt, os.Kill, syscall.SIGTERM, syscall.SIGHUP)
 	sig := <-osSignals
 	log.Debugf("Received signal: %v", sig)
-	t.Disconnect()
 }
 
 func setLogLevel(level string) {

--- a/tunnel/intra.go
+++ b/tunnel/intra.go
@@ -72,12 +72,12 @@ type intratunnel struct {
 // `tunWriter` is the downstream VPN tunnel
 // `dialer` and `config` will be used for all network activity.
 // `listener` will be notified at the completion of every tunneled socket.
-func NewIntraTunnel(fakedns string, dohdns doh.Transport, tunWriter io.Writer, dialer *net.Dialer, config *net.ListenConfig, listener IntraListener) (IntraTunnel, error) {
+func NewIntraTunnel(fakedns string, dohdns doh.Transport, tunWriter io.WriteCloser, dialer *net.Dialer, config *net.ListenConfig, listener IntraListener) (IntraTunnel, error) {
 	if tunWriter == nil {
 		return nil, errors.New("Must provide a valid TUN writer")
 	}
 	core.RegisterOutputFn(tunWriter.Write)
-	base := &tunnel{core.NewLWIPStack(), true}
+	base := &tunnel{tunWriter, core.NewLWIPStack(), true}
 	t := &intratunnel{
 		tunnel: base,
 	}

--- a/tunnel/intra.go
+++ b/tunnel/intra.go
@@ -69,7 +69,7 @@ type intratunnel struct {
 // `udpdns` and `tcpdns` are the actual location of the DNS server in use.
 //    These will normally be localhost with a high-numbered port.
 // `dohdns` is the initial DOH transport.
-// `tunWriter` is the downstream VPN tunnel
+// `tunWriter` is the downstream VPN tunnel.  IntraTunnel.Disconnect() will close `tunWriter`.
 // `dialer` and `config` will be used for all network activity.
 // `listener` will be notified at the completion of every tunneled socket.
 func NewIntraTunnel(fakedns string, dohdns doh.Transport, tunWriter io.WriteCloser, dialer *net.Dialer, config *net.ListenConfig, listener IntraListener) (IntraTunnel, error) {

--- a/tunnel/intra.go
+++ b/tunnel/intra.go
@@ -72,12 +72,12 @@ type intratunnel struct {
 // `tunWriter` is the downstream VPN tunnel
 // `dialer` and `config` will be used for all network activity.
 // `listener` will be notified at the completion of every tunneled socket.
-func NewIntraTunnel(fakedns string, dohdns doh.Transport, tunWriter io.WriteCloser, dialer *net.Dialer, config *net.ListenConfig, listener IntraListener) (IntraTunnel, error) {
+func NewIntraTunnel(fakedns string, dohdns doh.Transport, tunWriter io.Writer, dialer *net.Dialer, config *net.ListenConfig, listener IntraListener) (IntraTunnel, error) {
 	if tunWriter == nil {
 		return nil, errors.New("Must provide a valid TUN writer")
 	}
 	core.RegisterOutputFn(tunWriter.Write)
-	base := &tunnel{tunWriter, core.NewLWIPStack(), true}
+	base := &tunnel{core.NewLWIPStack(), true}
 	t := &intratunnel{
 		tunnel: base,
 	}

--- a/tunnel/outline.go
+++ b/tunnel/outline.go
@@ -54,7 +54,7 @@ type outlinetunnel struct {
 // `cipher` is the encryption cipher used by the Shadowsocks proxy.
 // `isUDPEnabled` indicates if the Shadowsocks proxy and the network support proxying UDP traffic.
 // `tunWriter` is used to output packets back to the TUN device.
-func NewOutlineTunnel(host string, port int, password, cipher string, isUDPEnabled bool, tunWriter io.Writer) (OutlineTunnel, error) {
+func NewOutlineTunnel(host string, port int, password, cipher string, isUDPEnabled bool, tunWriter io.WriteCloser) (OutlineTunnel, error) {
 	if tunWriter == nil {
 		return nil, errors.New("Must provide a TUN writer")
 	}
@@ -65,7 +65,7 @@ func NewOutlineTunnel(host string, port int, password, cipher string, isUDPEnabl
 	core.RegisterOutputFn(func(data []byte) (int, error) {
 		return tunWriter.Write(data)
 	})
-	base := &tunnel{core.NewLWIPStack(), true}
+	base := &tunnel{tunWriter, core.NewLWIPStack(), true}
 	t := &outlinetunnel{base, host, port, password, cipher, isUDPEnabled}
 	t.registerConnectionHandlers()
 	return t, nil

--- a/tunnel/outline.go
+++ b/tunnel/outline.go
@@ -54,7 +54,7 @@ type outlinetunnel struct {
 // `cipher` is the encryption cipher used by the Shadowsocks proxy.
 // `isUDPEnabled` indicates if the Shadowsocks proxy and the network support proxying UDP traffic.
 // `tunWriter` is used to output packets back to the TUN device.
-func NewOutlineTunnel(host string, port int, password, cipher string, isUDPEnabled bool, tunWriter io.WriteCloser) (OutlineTunnel, error) {
+func NewOutlineTunnel(host string, port int, password, cipher string, isUDPEnabled bool, tunWriter io.Writer) (OutlineTunnel, error) {
 	if tunWriter == nil {
 		return nil, errors.New("Must provide a TUN writer")
 	}
@@ -65,7 +65,7 @@ func NewOutlineTunnel(host string, port int, password, cipher string, isUDPEnabl
 	core.RegisterOutputFn(func(data []byte) (int, error) {
 		return tunWriter.Write(data)
 	})
-	base := &tunnel{tunWriter, core.NewLWIPStack(), true}
+	base := &tunnel{core.NewLWIPStack(), true}
 	t := &outlinetunnel{base, host, port, password, cipher, isUDPEnabled}
 	t.registerConnectionHandlers()
 	return t, nil

--- a/tunnel/outline.go
+++ b/tunnel/outline.go
@@ -53,7 +53,7 @@ type outlinetunnel struct {
 // `password` is the password of the Shadowsocks proxy.
 // `cipher` is the encryption cipher used by the Shadowsocks proxy.
 // `isUDPEnabled` indicates if the Shadowsocks proxy and the network support proxying UDP traffic.
-// `tunWriter` is used to output packets back to the TUN device.
+// `tunWriter` is used to output packets back to the TUN device.  OutlineTunnel.Disconnect() will close `tunWriter`.
 func NewOutlineTunnel(host string, port int, password, cipher string, isUDPEnabled bool, tunWriter io.WriteCloser) (OutlineTunnel, error) {
 	if tunWriter == nil {
 		return nil, errors.New("Must provide a TUN writer")

--- a/tunnel/tun.go
+++ b/tunnel/tun.go
@@ -1,7 +1,9 @@
 package tunnel
 
 import (
+	"errors"
 	"io"
+	"os"
 
 	"github.com/eycorsican/go-tun2socks/common/log"
 	_ "github.com/eycorsican/go-tun2socks/common/log/simple" // Import simple log for the side effect of making logs printable.
@@ -10,16 +12,22 @@ import (
 
 const vpnMtu = 1500
 
-// TUNFile is an io.ReadWriter wrapping a TUN file descriptor (UNIX platforms only).
-// This is a substitute for os.NewFile that avoids taking ownership of the file.
-type TUNFile int
-
-func (f TUNFile) Read(buf []byte) (int, error) {
-	return unix.Read(int(f), buf)
-}
-
-func (f TUNFile) Write(buf []byte) (int, error) {
-	return unix.Write(int(f), buf)
+// MakeTunFile returns an os.File object from a TUN file descriptor `fd`
+// without taking ownership of the file descriptor.
+func MakeTunFile(fd int) (*os.File, error) {
+	if fd < 0 {
+		return nil, errors.New("Must provide a valid TUN file descriptor")
+	}
+	// Make a copy of `fd` so that os.File's finalizer doesn't close `fd`.
+	newfd, err := unix.Dup(fd)
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(newfd), "")
+	if file == nil {
+		return nil, errors.New("Failed to open TUN file descriptor")
+	}
+	return file, nil
 }
 
 // ProcessInputPackets reads packets from a TUN device `tun` and writes them to `tunnel`.

--- a/tunnel/tun.go
+++ b/tunnel/tun.go
@@ -11,8 +11,10 @@ import (
 
 const vpnMtu = 1500
 
-// MakeTunFile returns an os.File object from a TUN file descriptor `fd`
-// without taking ownership of the file descriptor.  (UNIX only.)
+// MakeTunFile returns an os.File object from a TUN file descriptor `fd`.
+// The returned os.File holds a separate reference to the underlying file,
+// so the file will not be closed until both `fd` and the os.File are
+// separately closed.  (UNIX only.)
 func MakeTunFile(fd int) (*os.File, error) {
 	if fd < 0 {
 		return nil, errors.New("Must provide a valid TUN file descriptor")

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -47,6 +47,7 @@ func (t *tunnel) Disconnect() {
 	}
 	t.isConnected = false
 	t.lwipStack.Close()
+	t.tunWriter.Close()
 }
 
 func (t *tunnel) Write(data []byte) (int, error) {

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -16,6 +16,7 @@ package tunnel
 
 import (
 	"errors"
+	"io"
 
 	"github.com/eycorsican/go-tun2socks/core"
 )
@@ -31,6 +32,7 @@ type Tunnel interface {
 }
 
 type tunnel struct {
+	tunWriter   io.WriteCloser
 	lwipStack   core.LWIPStack
 	isConnected bool
 }

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -16,7 +16,6 @@ package tunnel
 
 import (
 	"errors"
-	"io"
 
 	"github.com/eycorsican/go-tun2socks/core"
 )
@@ -32,7 +31,6 @@ type Tunnel interface {
 }
 
 type tunnel struct {
-	tunWriter   io.WriteCloser
 	lwipStack   core.LWIPStack
 	isConnected bool
 }


### PR DESCRIPTION
os.NewFile takes ownership of the file descriptor, and adds a finalizer
that closes the file descriptor when the file is garbage-collected.
This violates Outline's interface contract (caller retains ownership of
the TUN device), and could cause a problem if the file descriptor is
still being used

See https://github.com/Jigsaw-Code/Intra/issues/285