### PR TITLE
Set Intra UDP NAT timeout to 5 minutes

### DIFF
--- a/intra/tunnel.go
+++ b/intra/tunnel.go
@@ -89,8 +89,8 @@ func NewTunnel(fakedns string, dohdns doh.Transport, tunWriter io.WriteCloser, d
 
 // Registers Intra's custom UDP and TCP connection handlers to the tun2socks core.
 func (t *intratunnel) registerConnectionHandlers(fakedns string, dialer *net.Dialer, config *net.ListenConfig, listener Listener) error {
-	// RFC 5382 REQ-5 requires a timeout no shorter than 2 hours and 4 minutes.
-	timeout, _ := time.ParseDuration("2h4m")
+	// RFC 4787 REQ-5 requires a timeout no shorter than 5 minutes.
+	timeout, _ := time.ParseDuration("5m")
 
 	udpfakedns, err := net.ResolveUDPAddr("udp", fakedns)
 	if err != nil {


### PR DESCRIPTION
A significant amount of UDP connections on Android are DNS requests.
An hour long timeout for them isn't really helpful especially considering DNS
TTLs themselves are considerably shorter. Besides, RFC 4787 recommends
at least a timeout of 5mins, which is still high for DNS, but may work nicely for
other UDP connections, at least according to the RFC.

#72 