### PR TITLE
Fix xgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ $(GOMOBILE): go.mod
 	$(GOMOBILE) init
 
 $(XGO): go.mod
-	GOBIN=$(GOBIN) go install src.techknowlogick.com/xgo
+	GOBIN=$(GOBIN) go install github.com/crazy-max/xgo
 
 go.mod: tools.go
 	go mod tidy

--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ We build binaries for Linux and Windows from source without any custom integrati
 
 ### Set up
 
-- [Docker](https://docs.docker.com/get-docker/) (for XGO)
-- [xgo](https://github.com/techknowlogick/xgo) (installed as needed by `make`)
+- [Docker](https://docs.docker.com/get-docker/) (for xgo)
+- [xgo](https://github.com/crazy-max/xgo) (installed as needed by `make`)
+- [ghcr.io/crazy-max/xgo Docker image](https://github.com/crazy-max/xgo/pkgs/container/xgo). This is pulled automatically by xgo and takes ~6.8 GB of disk space.
 
 ## Build
 

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/Jigsaw-Code/choir v1.0.1
 	github.com/Jigsaw-Code/getsni v0.0.0-20190807203514-efe2dbf35d1f
 	github.com/Jigsaw-Code/outline-ss-server v1.3.5
+	github.com/crazy-max/xgo v0.14.0
 	github.com/eycorsican/go-tun2socks v1.16.11
 	golang.org/x/mobile v0.0.0-20220407111146-e579adbbc4a2
 	golang.org/x/net v0.0.0-20220412020605-290c469a71a5
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
-	src.techknowlogick.com/xgo v1.4.1-0.20220413212431-091a0a22b814
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/crazy-max/xgo v0.14.0 h1:/GGO0os0F0QdCmuxwQA9b68JaYXk8TCT6Fc1MUbIHgc=
+github.com/crazy-max/xgo v0.14.0/go.mod h1:m/aqfKaN/cYzfw+Pzk7Mk0tkmShg3/rCS4Zdhdugi4o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -161,5 +163,3 @@ gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-src.techknowlogick.com/xgo v1.4.1-0.20220413212431-091a0a22b814 h1:/oIyHjKnlyQ3yFzxq7uin83l6h0sHXT7Z+9TpP9wr8s=
-src.techknowlogick.com/xgo v1.4.1-0.20220413212431-091a0a22b814/go.mod h1:31CE1YKtDOrKTk9PSnjTpe6YbO6W/0LTYZ1VskL09oU=

--- a/tools.go
+++ b/tools.go
@@ -21,6 +21,6 @@
 package tools
 
 import (
+	_ "github.com/crazy-max/xgo"
 	_ "golang.org/x/mobile/cmd/gomobile"
-	_ "src.techknowlogick.com/xgo"
 )


### PR DESCRIPTION
Migrate from the outdated and unmaintained src.techknowlogick.com/xgo to github.com/crazy-max/xgo.
The old one doesn't seem to support Go modules properly.

/cc @jyyi1