### PR TITLE
cleanup: Refactor tunnel creation function arguments

### DIFF
--- a/outline/android/tun2socks.go
+++ b/outline/android/tun2socks.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/Jigsaw-Code/outline-go-tun2socks/outline"
 	"github.com/Jigsaw-Code/outline-go-tun2socks/tunnel"
+	"github.com/Jigsaw-Code/outline-ss-server/client"
 	"github.com/eycorsican/go-tun2socks/common/log"
 )
 
@@ -58,7 +59,11 @@ func ConnectShadowsocksTunnel(fd int, host string, port int, password, cipher st
 	if err != nil {
 		return nil, err
 	}
-	t, err := outline.NewTunnel(host, port, password, cipher, isUDPEnabled, tun)
+	ssclient, err := client.NewClient(host, port, password, cipher)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct Shadowsocks client: %v", err)
+	}
+	t, err := outline.NewTunnel(ssclient, isUDPEnabled, tun)
 	if err != nil {
 		return nil, err
 	}

--- a/outline/apple/tun2socks.go
+++ b/outline/apple/tun2socks.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/Jigsaw-Code/outline-go-tun2socks/outline"
+	"github.com/Jigsaw-Code/outline-ss-server/client"
 )
 
 // OutlineTunnel embeds the tun2socks.Tunnel interface so it gets exported by gobind.
@@ -66,5 +67,10 @@ func ConnectShadowsocksTunnel(tunWriter TunWriter, host string, port int, passwo
 	} else if port <= 0 || port > math.MaxUint16 {
 		return nil, fmt.Errorf("Invalid port number: %v", port)
 	}
-	return outline.NewTunnel(host, port, password, cipher, isUDPEnabled, tunWriter)
+	ssclient, err := client.NewClient(host, port, password, cipher)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct Shadowsocks client: %v", err)
+	}
+
+	return outline.NewTunnel(ssclient, isUDPEnabled, tunWriter)
 }

--- a/shadowsocks/tcp.go
+++ b/shadowsocks/tcp.go
@@ -3,8 +3,8 @@ package shadowsocks
 import (
 	"net"
 
-	onet "github.com/Jigsaw-Code/outline-ss-server/net"
 	shadowsocks "github.com/Jigsaw-Code/outline-ss-server/client"
+	onet "github.com/Jigsaw-Code/outline-ss-server/net"
 	"github.com/eycorsican/go-tun2socks/core"
 )
 
@@ -13,16 +13,7 @@ type tcpHandler struct {
 }
 
 // NewTCPHandler returns a Shadowsocks TCP connection handler.
-//
-// `host` is the hostname of the Shadowsocks proxy server.
-// `port` is the port of the Shadowsocks proxy server.
-// `password` is password used to authenticate to the server.
-// `cipher` is the encryption cipher of the Shadowsocks proxy.
-func NewTCPHandler(host string, port int, password, cipher string) core.TCPConnHandler {
-	client, err := shadowsocks.NewClient(host, port, password, cipher)
-	if err != nil {
-		return nil
-	}
+func NewTCPHandler(client shadowsocks.Client) core.TCPConnHandler {
 	return &tcpHandler{client}
 }
 

--- a/shadowsocks/udp.go
+++ b/shadowsocks/udp.go
@@ -20,16 +20,9 @@ type udpHandler struct {
 
 // NewUDPHandler returns a Shadowsocks UDP connection handler.
 //
-// `host` is the hostname of the Shadowsocks proxy server.
-// `port` is the port of the Shadowsocks proxy.
-// `password` is password used to authenticate to the proxy.
-// `cipher` is the encryption cipher of the Shadowsocks proxy.
+// `client` provides the Shadowsocks functionality.
 // `timeout` is the UDP read and write timeout.
-func NewUDPHandler(host string, port int, password, cipher string, timeout time.Duration) core.UDPConnHandler {
-	client, err := shadowsocks.NewClient(host, port, password, cipher)
-	if err != nil {
-		return nil
-	}
+func NewUDPHandler(client shadowsocks.Client, timeout time.Duration) core.UDPConnHandler {
 	return &udpHandler{
 		client:  client,
 		timeout: timeout,


### PR DESCRIPTION
This change moves Shadowsocks client setup to the caller, which avoids passing a large number of arguments across several packages and enables more flexibility for changes to the Shadowsocks client configuration (starting with #95).