### PR TITLE
Use the specified prefix for the connectivity checks

### DIFF
--- a/outline/shadowsocks/config.go
+++ b/outline/shadowsocks/config.go
@@ -1,0 +1,50 @@
+// Copyright 2022 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shadowsocks
+
+import (
+	"github.com/Jigsaw-Code/outline-ss-server/client"
+	"github.com/eycorsican/go-tun2socks/common/log"
+)
+
+// Config represents a shadowsocks server configuration.
+// Exported via gobind.
+type Config struct {
+	Host       string
+	Port       int
+	Password   string
+	CipherName string
+	Prefix     []byte
+}
+
+// Client provides a transparent container for [client.Client] that
+// is exportable (as an opaque object) via gobind.
+type Client struct {
+	client.Client
+}
+
+// NewClient provides a gobind-compatible wrapper for [client.NewClient].
+func NewClient(config *Config) (*Client, error) {
+	c, err := client.NewClient(config.Host, config.Port, config.Password, config.CipherName)
+	if err != nil {
+		return nil, err
+	}
+	if len(config.Prefix) > 0 {
+		log.Debugf("Using salt prefix: %s", string(config.Prefix))
+		c.SetTCPSaltGenerator(client.NewPrefixSaltGenerator(config.Prefix))
+	}
+
+	return &Client{c}, nil
+}

--- a/outline/shadowsocks/connectivity.go
+++ b/outline/shadowsocks/connectivity.go
@@ -32,7 +32,7 @@ const reachabilityTimeout = 10 * time.Second
 // the current network. Parallelizes the execution of TCP and UDP checks, selects the appropriate
 // error code to return accounting for transient network failures.
 // Returns an error if an unexpected error ocurrs.
-func CheckConnectivity(host string, port int, client shadowsocks.Client) (int, error) {
+func CheckConnectivity(client *Client) (int, error) {
 	tcpChan := make(chan error)
 	// Check whether the proxy is reachable and that the client is able to authenticate to the proxy
 	go func() {

--- a/outline/shadowsocks/connectivity.go
+++ b/outline/shadowsocks/connectivity.go
@@ -32,12 +32,7 @@ const reachabilityTimeout = 10 * time.Second
 // the current network. Parallelizes the execution of TCP and UDP checks, selects the appropriate
 // error code to return accounting for transient network failures.
 // Returns an error if an unexpected error ocurrs.
-func CheckConnectivity(host string, port int, password, cipher string) (int, error) {
-	client, err := shadowsocks.NewClient(host, port, password, cipher)
-	if err != nil {
-		// TODO: Inspect error for invalid cipher error or proxy host resolution failure.
-		return Unexpected, err
-	}
+func CheckConnectivity(host string, port int, client shadowsocks.Client) (int, error) {
 	tcpChan := make(chan error)
 	// Check whether the proxy is reachable and that the client is able to authenticate to the proxy
 	go func() {


### PR DESCRIPTION
This ensures that the connectivity checks more accurately match real connections to that server.