### PR TITLE
fix: adjust connectivity check heuristics

### DIFF
--- a/outline/shadowsocks/connectivity.go
+++ b/outline/shadowsocks/connectivity.go
@@ -40,14 +40,11 @@ func CheckConnectivity(client *Client) (int, error) {
 	}()
 	// Check whether UDP is supported
 	udpErr := oss.CheckUDPConnectivityWithDNS(client, shadowsocks.NewAddr("1.1.1.1:53", "udp"))
-	if udpErr == nil {
-		// The UDP connectvity check is a superset of the TCP checks. If the other tests fail,
-		// assume it's due to intermittent network conditions and declare success anyway.
-		return NoError, nil
-	}
 	tcpErr := <-tcpChan
 	if tcpErr == nil {
-		// The TCP connectivity checks succeeded, which means UDP is not supported.
+		if udpErr == nil {
+			return NoError, nil
+		}
 		return UDPConnectivity, nil
 	}
 	_, isReachabilityError := tcpErr.(*oss.ReachabilityError)

--- a/shadowsocks/connectivity.go
+++ b/shadowsocks/connectivity.go
@@ -13,7 +13,7 @@ import (
 const (
 	tcpTimeoutMs        = udpTimeoutMs * udpMaxRetryAttempts
 	udpTimeoutMs        = 1000
-	udpMaxRetryAttempts = 5
+	udpMaxRetryAttempts = 10
 	bufferLength        = 512
 )
 

--- a/shadowsocks/connectivity.go
+++ b/shadowsocks/connectivity.go
@@ -11,9 +11,9 @@ import (
 
 // TODO: make these values configurable by exposing a struct with the connectivity methods.
 const (
-	tcpTimeoutMs        = udpTimeoutMs * udpMaxRetryAttempts
-	udpTimeoutMs        = 1000
-	udpMaxRetryAttempts = 10
+	tcpTimeout          = 10 * time.Second
+	udpTimeout          = 1 * time.Second
+	udpMaxRetryAttempts = 5
 	bufferLength        = 512
 )
 
@@ -38,7 +38,7 @@ func CheckUDPConnectivityWithDNS(client shadowsocks.Client, resolverAddr net.Add
 	defer conn.Close()
 	buf := make([]byte, bufferLength)
 	for attempt := 0; attempt < udpMaxRetryAttempts; attempt++ {
-		conn.SetDeadline(time.Now().Add(time.Millisecond * udpTimeoutMs))
+		conn.SetDeadline(time.Now().Add(udpTimeout))
 		_, err := conn.WriteTo(getDNSRequest(), resolverAddr)
 		if err != nil {
 			continue
@@ -73,7 +73,7 @@ func CheckTCPConnectivityWithHTTP(client shadowsocks.Client, targetURL string) e
 		return &ReachabilityError{err}
 	}
 	defer conn.Close()
-	conn.SetDeadline(time.Now().Add(time.Millisecond * tcpTimeoutMs))
+	conn.SetDeadline(time.Now().Add(tcpTimeout))
 	err = req.Write(conn)
 	if err != nil {
 		return &AuthenticationError{err}


### PR DESCRIPTION
This change adjusts the connectivity check to fix two issues reported by users:

1. On low-quality networks, the test sometimes fails even though the server is reachable.  This is addressed by lengthening the timeouts.
2. On networks that are blocking TCP access to the server, the test will succeed if UDP access is working, even though the server is effectively unusable.

This change has the negative effect of slowing down the connectivity check for all users.  If the server is working, the user must wait longer because both the UDP and TCP tests must complete, and the TCP test is slower than the UDP test.  If the server is unreachable, the test will wait for twice as long (10 seconds) before failing.