### PR TITLE
fix(build): Makefile maintenance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GOBIN=$(CURDIR)/bin
 
 GOMOBILE=$(GOBIN)/gomobile
 # Add GOBIN to $PATH so `gomobile` can find `gobind`.
-GOBIND=env PATH=$(GOBIN):$(PATH) $(GOMOBILE) bind
+GOBIND=env PATH="$(GOBIN):$(PATH)" "$(GOMOBILE)" bind
 IMPORT_PATH=github.com/Jigsaw-Code/outline-go-tun2socks
 
 .PHONY: android apple linux windows intra clean clean-all
@@ -16,15 +16,14 @@ ANDROID_BUILD_CMD=$(GOBIND) -a -ldflags '-w' -target=android -tags android -work
 intra: $(BUILDDIR)/intra/tun2socks.aar
 
 $(BUILDDIR)/intra/tun2socks.aar: $(GOMOBILE)
-	mkdir -p $(BUILDDIR)/intra
-	$(ANDROID_BUILD_CMD) -o $@ $(IMPORT_PATH)/intra $(IMPORT_PATH)/intra/android $(IMPORT_PATH)/intra/doh $(IMPORT_PATH)/intra/split $(IMPORT_PATH)/intra/protect
-
+	mkdir -p "$(BUILDDIR)/intra"
+	$(ANDROID_BUILD_CMD) -o "$@" $(IMPORT_PATH)/intra $(IMPORT_PATH)/intra/android $(IMPORT_PATH)/intra/doh $(IMPORT_PATH)/intra/split $(IMPORT_PATH)/intra/protect
 
 android: $(BUILDDIR)/android/tun2socks.aar
 
 $(BUILDDIR)/android/tun2socks.aar: $(GOMOBILE)
-	mkdir -p $(BUILDDIR)/android
-	$(ANDROID_BUILD_CMD) -o $@ $(IMPORT_PATH)/outline/android $(IMPORT_PATH)/outline/shadowsocks
+	mkdir -p "$(BUILDDIR)/android"
+	$(ANDROID_BUILD_CMD) -o "$@" $(IMPORT_PATH)/outline/android $(IMPORT_PATH)/outline/shadowsocks
 
 
 apple: $(BUILDDIR)/apple/Tun2socks.xcframework
@@ -46,8 +45,9 @@ LINUX_BUILDDIR=$(BUILDDIR)/linux
 linux: $(LINUX_BUILDDIR)/tun2socks
 
 $(LINUX_BUILDDIR)/tun2socks: $(XGO)
-	$(XGO) -ldflags $(XGO_LDFLAGS) --targets=linux/amd64 -dest $(LINUX_BUILDDIR) $(ELECTRON_PATH)
-	mv $(LINUX_BUILDDIR)/electron-linux-amd64 $@
+	mkdir -p "$(LINUX_BUILDDIR)"
+	$(XGO) -ldflags $(XGO_LDFLAGS) --targets=linux/amd64 -dest "$(LINUX_BUILDDIR)" "$(ELECTRON_PATH)"
+	mv "$(LINUX_BUILDDIR)/electron-linux-amd64" "$@"
 
 
 WINDOWS_BUILDDIR=$(BUILDDIR)/windows
@@ -55,24 +55,25 @@ WINDOWS_BUILDDIR=$(BUILDDIR)/windows
 windows: $(WINDOWS_BUILDDIR)/tun2socks.exe
 
 $(WINDOWS_BUILDDIR)/tun2socks.exe: $(XGO)
-	$(XGO) -ldflags $(XGO_LDFLAGS) --targets=windows/386 -dest $(WINDOWS_BUILDDIR) $(ELECTRON_PATH)
-	mv $(WINDOWS_BUILDDIR)/electron-windows-4.0-386.exe $@
+	mkdir -p "$(WINDOWS_BUILDDIR)"
+	$(XGO) -ldflags $(XGO_LDFLAGS) --targets=windows/386 -dest "$(WINDOWS_BUILDDIR)" "$(ELECTRON_PATH)"
+	mv "$(WINDOWS_BUILDDIR)/electron-windows-386.exe" "$@"
 
 
 $(GOMOBILE): go.mod
-	env GOBIN=$(GOBIN) go install golang.org/x/mobile/cmd/gomobile
-	env GOBIN=$(GOBIN) $(GOMOBILE) init
+	env GOBIN="$(GOBIN)" go install golang.org/x/mobile/cmd/gomobile
+	env GOBIN="$(GOBIN)" $(GOMOBILE) init
 
 $(XGO): go.mod
-	env GOBIN=$(GOBIN) go install github.com/crazy-max/xgo
+	env GOBIN="$(GOBIN)" go install github.com/crazy-max/xgo
 
 go.mod: tools.go
 	go mod tidy
 	touch go.mod
 
 clean:
-	rm -rf $(BUILDDIR)
+	rm -rf "$(BUILDDIR)"
 	go clean
 
 clean-all: clean
-	rm -rf $(GOBIN)
+	rm -rf "$(GOBIN)"

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ apple: $(BUILDDIR)/apple/Tun2socks.xcframework
 $(BUILDDIR)/apple/Tun2socks.xcframework: $(GOMOBILE)
   # MACOSX_DEPLOYMENT_TARGET and -iosversion should match what outline-client supports.
   # TODO(fortuna): -s strips symbols and is obsolete. Why are we using it?
-	export MACOSX_DEPLOYMENT_TARGET=10.14; $(GOBIND) -iosversion=9.0 -target=ios,iossimulator,macos -o $@ -ldflags '-s -w' -bundleid org.outline.tun2socks $(IMPORT_PATH)/outline/apple $(IMPORT_PATH)/outline/shadowsocks
+	export MACOSX_DEPLOYMENT_TARGET=10.14; $(GOBIND) -iosversion=9.0 -target=ios,iossimulator,macos,maccatalyst -o $@ -ldflags '-s -w' -bundleid org.outline.tun2socks $(IMPORT_PATH)/outline/apple $(IMPORT_PATH)/outline/shadowsocks
 
 
 XGO=$(GOBIN)/xgo


### PR DESCRIPTION
There are three main changes here:

1. Add the Mac Catalyst platform to the Apple target.
2. Add quotes around variables that might contain spaces and get passed to the shell.
3. Pre-create the build directories for Linux and Windows.  (Otherwise, these directories are created on-demand by the xgo Docker image, which results in them being owned by root and read-only to the user.)