### PR TITLE
fix(build/electron): build the current branch

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,11 +62,16 @@ jobs:
       - name: Set XCode Version
         run: sudo xcode-select -switch /Applications/Xcode_13.3.app
 
+      - name: Change Go version to 1.18
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^1.18'
+
       - name: Build for Apple platforms
-      # Change the Go version to 1.18.  (Default is 1.17.)
-        run: |
-          env PATH="${GOROOT_1_18_X64}:${PATH}"
-          make apple
+        run: make apple
+        
+      - name: Build future Apple library
+        run: make apple_future
 
   android:
     name: Android Build

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ GOBIN=$(CURDIR)/bin
 GOMOBILE=$(GOBIN)/gomobile
 # Add GOBIN to $PATH so `gomobile` can find `gobind`.
 GOBIND=env PATH="$(GOBIN):$(PATH)" "$(GOMOBILE)" bind
-IMPORT_PATH=github.com/Jigsaw-Code/outline-go-tun2socks
+IMPORT_HOST=github.com
+IMPORT_PATH=$(IMPORT_HOST)/Jigsaw-Code/outline-go-tun2socks
 
 .PHONY: android apple apple_future linux windows intra clean clean-all
 
@@ -41,7 +42,7 @@ $(BUILDDIR)/apple_future/Tun2socks.xcframework: $(GOMOBILE)
 XGO=$(GOBIN)/xgo
 TUN2SOCKS_VERSION=v1.16.11
 XGO_LDFLAGS='-s -w -X main.version=$(TUN2SOCKS_VERSION)'
-ELECTRON_PATH=$(IMPORT_PATH)/outline/electron
+ELECTRON_PKG=outline/electron
 
 
 LINUX_BUILDDIR=$(BUILDDIR)/linux
@@ -49,9 +50,10 @@ LINUX_BUILDDIR=$(BUILDDIR)/linux
 linux: $(LINUX_BUILDDIR)/tun2socks
 
 $(LINUX_BUILDDIR)/tun2socks: $(XGO)
-	mkdir -p "$(LINUX_BUILDDIR)"
-	$(XGO) -ldflags $(XGO_LDFLAGS) --targets=linux/amd64 -dest "$(LINUX_BUILDDIR)" "$(ELECTRON_PATH)"
-	mv "$(LINUX_BUILDDIR)/electron-linux-amd64" "$@"
+	mkdir -p "$(LINUX_BUILDDIR)/$(IMPORT_PATH)"
+	$(XGO) -ldflags $(XGO_LDFLAGS) --targets=linux/amd64 -dest "$(LINUX_BUILDDIR)" -pkg $(ELECTRON_PKG) .
+	mv "$(LINUX_BUILDDIR)/$(IMPORT_PATH)-linux-amd64" "$@"
+	rm -r "$(LINUX_BUILDDIR)/$(IMPORT_HOST)"
 
 
 WINDOWS_BUILDDIR=$(BUILDDIR)/windows
@@ -59,9 +61,10 @@ WINDOWS_BUILDDIR=$(BUILDDIR)/windows
 windows: $(WINDOWS_BUILDDIR)/tun2socks.exe
 
 $(WINDOWS_BUILDDIR)/tun2socks.exe: $(XGO)
-	mkdir -p "$(WINDOWS_BUILDDIR)"
-	$(XGO) -ldflags $(XGO_LDFLAGS) --targets=windows/386 -dest "$(WINDOWS_BUILDDIR)" "$(ELECTRON_PATH)"
-	mv "$(WINDOWS_BUILDDIR)/electron-windows-386.exe" "$@"
+	mkdir -p "$(WINDOWS_BUILDDIR)/$(IMPORT_PATH)"
+	$(XGO) -ldflags $(XGO_LDFLAGS) --targets=windows/386 -dest "$(WINDOWS_BUILDDIR)" -pkg $(ELECTRON_PKG) .
+	mv "$(WINDOWS_BUILDDIR)/$(IMPORT_PATH)-windows-386.exe" "$@"
+	rm -r "$(WINDOWS_BUILDDIR)/$(IMPORT_HOST)"
 
 
 $(GOMOBILE): go.mod


### PR DESCRIPTION
Currently, `make linux` and `make windows` download and build the `master` branch, ignoring any changes in the local repository.  This change makes these commands build the local repository instead.