### PR TITLE
Accept JSON-formatted Shadowsocks configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,9 @@ $(BUILDDIR)/intra/tun2socks.aar: $(GOMOBILE)
 android: $(BUILDDIR)/android/tun2socks.aar
 
 $(BUILDDIR)/android/tun2socks.aar: $(GOMOBILE)
-	mkdir -p "$(BUILDDIR)/android"
-	$(ANDROID_BUILD_CMD) -o "$@" $(IMPORT_PATH)/outline/android $(IMPORT_PATH)/outline/shadowsocks
+	mkdir -p "$(BUILDDIR)/android"	
+  # TODO: Don't expose /outline/shadowsocks to the platform code
+	$(ANDROID_BUILD_CMD) -o "$@" $(IMPORT_PATH)/outline/android $(IMPORT_PATH)/outline/shadowsocks $(IMPORT_PATH)/outline/proxy
 
 
 apple: $(BUILDDIR)/apple/Tun2socks.xcframework
@@ -31,7 +32,8 @@ apple: $(BUILDDIR)/apple/Tun2socks.xcframework
 $(BUILDDIR)/apple/Tun2socks.xcframework: $(GOMOBILE)
   # MACOSX_DEPLOYMENT_TARGET and -iosversion should match what outline-client supports.
   # TODO(fortuna): -s strips symbols and is obsolete. Why are we using it?
-	export MACOSX_DEPLOYMENT_TARGET=10.14; $(GOBIND) -iosversion=9.0 -target=ios,iossimulator,macos -o $@ -ldflags '-s -w' -bundleid org.outline.tun2socks $(IMPORT_PATH)/outline/apple $(IMPORT_PATH)/outline/shadowsocks
+  # TODO: Don't expose /outline/shadowsocks to the platform code
+	export MACOSX_DEPLOYMENT_TARGET=10.14; $(GOBIND) -iosversion=9.0 -target=ios,iossimulator,macos -o $@ -ldflags '-s -w' -bundleid org.outline.tun2socks $(IMPORT_PATH)/outline/apple $(IMPORT_PATH)/outline/shadowsocks  $(IMPORT_PATH)/outline/proxy
 
 
 XGO=$(GOBIN)/xgo

--- a/outline/android/tun2socks.go
+++ b/outline/android/tun2socks.go
@@ -18,6 +18,7 @@ import (
 	"runtime/debug"
 
 	"github.com/Jigsaw-Code/outline-go-tun2socks/outline"
+	"github.com/Jigsaw-Code/outline-go-tun2socks/outline/proxy"
 	"github.com/Jigsaw-Code/outline-go-tun2socks/outline/shadowsocks"
 	"github.com/Jigsaw-Code/outline-go-tun2socks/tunnel"
 	"github.com/eycorsican/go-tun2socks/common/log"
@@ -46,7 +47,25 @@ type OutlineTunnel interface {
 //
 // Throws an exception if the TUN file descriptor cannot be opened, or if the tunnel fails to
 // connect.
+//
+// Deprecated: Use ConnectProxyTunnel
 func ConnectShadowsocksTunnel(fd int, client *shadowsocks.Client, isUDPEnabled bool) (OutlineTunnel, error) {
+	return ConnectProxyTunnel(fd, &proxy.Client{Client: client}, isUDPEnabled)
+}
+
+// ConnectProxyTunnel reads packets from a TUN device and routes it to a proxy server.
+// Returns an OutlineTunnel instance and does *not* take ownership of the TUN file descriptor; the
+// caller is responsible for closing after OutlineTunnel disconnects.
+//
+//   - `fd` is the TUN device.  The OutlineTunnel acquires an additional reference to it, which
+//     is released by OutlineTunnel.Disconnect(), so the caller must close `fd` _and_ call
+//     Disconnect() in order to close the TUN device.
+//   - `client` is the proxy client (created by [client.NewClient]).
+//   - `isUDPEnabled` indicates whether the tunnel and/or network enable UDP proxying.
+//
+// Throws an exception if the TUN file descriptor cannot be opened, or if the tunnel fails to
+// connect.
+func ConnectProxyTunnel(fd int, client *proxy.Client, isUDPEnabled bool) (OutlineTunnel, error) {
 	tun, err := tunnel.MakeTunFile(fd)
 	if err != nil {
 		return nil, err

--- a/outline/android/tun2socks.go
+++ b/outline/android/tun2socks.go
@@ -45,7 +45,7 @@ type OutlineTunnel interface {
 //   - `client` is the Shadowsocks client (created by [shadowsocks.NewClient]).
 //   - `isUDPEnabled` indicates whether the tunnel and/or network enable UDP proxying.
 //
-// Throws an exception if the TUN file descriptor cannot be opened, or if the tunnel fails to
+// Returns an error if the TUN file descriptor cannot be opened, or if the tunnel fails to
 // connect.
 //
 // Deprecated: Use ConnectProxyTunnel
@@ -63,7 +63,7 @@ func ConnectShadowsocksTunnel(fd int, client *shadowsocks.Client, isUDPEnabled b
 //   - `client` is the proxy client (created by [proxy.NewClient]).
 //   - `isUDPEnabled` indicates whether the tunnel and/or network enable UDP proxying.
 //
-// Throws an exception if the TUN file descriptor cannot be opened, or if the tunnel fails to
+// Returns an error if the TUN file descriptor cannot be opened, or if the tunnel fails to
 // connect.
 func ConnectProxyTunnel(fd int, client *proxy.Client, isUDPEnabled bool) (OutlineTunnel, error) {
 	tun, err := tunnel.MakeTunFile(fd)

--- a/outline/apple/tun2socks.go
+++ b/outline/apple/tun2socks.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/Jigsaw-Code/outline-go-tun2socks/outline"
+	"github.com/Jigsaw-Code/outline-go-tun2socks/outline/proxy"
 	"github.com/Jigsaw-Code/outline-go-tun2socks/outline/shadowsocks"
 )
 
@@ -56,7 +57,26 @@ func init() {
 // `isUDPEnabled` indicates whether the tunnel and/or network enable UDP proxying.
 //
 // Sets an error if the tunnel fails to connect.
+//
+// Deprecated: Use ConnectProxyTunnel instead.
 func ConnectShadowsocksTunnel(tunWriter TunWriter, client *shadowsocks.Client, isUDPEnabled bool) (OutlineTunnel, error) {
+	if tunWriter == nil {
+		return nil, errors.New("must provide a TunWriter")
+	} else if client == nil {
+		return nil, errors.New("must provide a client")
+	}
+	return outline.NewTunnel(client, isUDPEnabled, tunWriter)
+}
+
+// ConnectTunnel reads packets from a TUN device and routes it to a proxy server.
+// Returns an OutlineTunnel instance that should be used to input packets to the tunnel.
+//
+// `tunWriter` is used to output packets to the TUN (VPN).
+// `client` is the proxy client (created by [client.NewClient]).
+// `isUDPEnabled` indicates whether the tunnel and/or network enable UDP proxying.
+//
+// Sets an error if the tunnel fails to connect.
+func ConnectProxyTunnel(tunWriter TunWriter, client *proxy.Client, isUDPEnabled bool) (OutlineTunnel, error) {
 	if tunWriter == nil {
 		return nil, errors.New("must provide a TunWriter")
 	} else if client == nil {

--- a/outline/proxy/config.go
+++ b/outline/proxy/config.go
@@ -1,0 +1,96 @@
+// Copyright 2022 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This package provides a highly abstracted client interface for use by
+// the platform code via `gobind`.  The exposed functions allow the platform
+// code to convert an opaque proxy configuration string into an opaque client
+// object and check that the client object is functioning (i.e. able to connect).
+// This package currently only offers basic Shadowsocks support, but over time it
+// may grow to support other protocols without altering the API as seen by the
+// platform code.
+package proxy
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	shadowsocks "github.com/Jigsaw-Code/outline-ss-server/client"
+	"github.com/eycorsican/go-tun2socks/common/log"
+)
+
+// Must match the ShadowsocksSessionConfig interface in Typescript.
+type configJSON struct {
+	Host     string
+	Port     uint16
+	Password string
+	Method   string
+	Prefix   string
+}
+
+// Client provides a transparent container for [client.Client] that
+// is exportable (as an opaque object) via gobind.
+type Client struct {
+	shadowsocks.Client
+}
+
+// The prefix is an 8-bit-clean byte sequence, stored in the codepoint
+// values of a unicode string, which arrives here encoded in UTF-8.
+func extractPrefixBytes(prefixUtf8 string) ([]byte, error) {
+	prefixRunes := []rune(prefixUtf8)
+	prefixBytes := make([]byte, len(prefixRunes))
+	for i, r := range prefixRunes {
+		if (r & 0xFF) != r {
+			return nil, fmt.Errorf("character out of range: %d", r)
+		}
+		prefixBytes[i] = byte(r)
+	}
+	return prefixBytes, nil
+}
+
+// newConfig parses a UTF-8 JSON string into a struct.
+// A string is used to ensure that configs can be passed through gobind.
+func newConfig(s string) (*configJSON, error) {
+	var parsed configJSON
+	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
+		return nil, err
+	}
+	if len(parsed.Host) == 0 || parsed.Port == 0 || len(parsed.Method) == 0 || len(parsed.Password) == 0 {
+		return nil, errors.New("missing mandatory field")
+	}
+	return &parsed, nil
+}
+
+// NewClient provides a gobind-compatible wrapper for [client.NewClient].
+// [configStr] contains a JSON configuration object.
+func NewClient(configStr string) (*Client, error) {
+	config, err := newConfig(configStr)
+	if err != nil {
+		return nil, err
+	}
+	c, err := shadowsocks.NewClient(config.Host, int(config.Port), config.Password, config.Method)
+	if err != nil {
+		return nil, err
+	}
+	if len(config.Prefix) > 0 {
+		log.Debugf("Using salt prefix: %s", string(config.Prefix))
+		prefixBytes, err := extractPrefixBytes(config.Prefix)
+		if err != nil {
+			return nil, fmt.Errorf("invalid prefix: %v", err)
+		}
+		c.SetTCPSaltGenerator(shadowsocks.NewPrefixSaltGenerator(prefixBytes))
+	}
+
+	return &Client{c}, nil
+}

--- a/outline/proxy/connectivity.go
+++ b/outline/proxy/connectivity.go
@@ -1,0 +1,85 @@
+// Copyright 2023 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"errors"
+	"net"
+	"strconv"
+	"time"
+
+	oss "github.com/Jigsaw-Code/outline-go-tun2socks/shadowsocks"
+	shadowsocks "github.com/Jigsaw-Code/outline-ss-server/client"
+)
+
+// Outline error codes. Must be kept in sync with definitions in outline-client/cordova-plugin-outline/outlinePlugin.js
+const (
+	NoError                     = 0
+	Unexpected                  = 1
+	NoVPNPermissions            = 2
+	AuthenticationFailure       = 3
+	UDPConnectivity             = 4
+	Unreachable                 = 5
+	VpnStartFailure             = 6
+	IllegalConfiguration        = 7
+	ShadowsocksStartFailure     = 8
+	ConfigureSystemProxyFailure = 9
+	NoAdminPermissions          = 10
+	UnsupportedRoutingTable     = 11
+	SystemMisconfigured         = 12
+)
+
+const reachabilityTimeout = 10 * time.Second
+
+// CheckConnectivity determines whether the Shadowsocks proxy can relay TCP and UDP traffic under
+// the current network. Parallelizes the execution of TCP and UDP checks, selects the appropriate
+// error code to return accounting for transient network failures.
+// Returns an error if an unexpected error ocurrs.
+func CheckConnectivity(client *Client) (int, error) {
+	// Start asynchronous UDP support check.
+	udpChan := make(chan error)
+	go func() {
+		udpChan <- oss.CheckUDPConnectivityWithDNS(client, shadowsocks.NewAddr("1.1.1.1:53", "udp"))
+	}()
+	// Check whether the proxy is reachable and that the client is able to authenticate to the proxy
+	tcpErr := oss.CheckTCPConnectivityWithHTTP(client, "http://example.com")
+	if tcpErr == nil {
+		udpErr := <-udpChan
+		if udpErr == nil {
+			return NoError, nil
+		}
+		return UDPConnectivity, nil
+	}
+	var authErr *oss.AuthenticationError
+	var reachabilityErr *oss.ReachabilityError
+	if errors.As(tcpErr, &authErr) {
+		return AuthenticationFailure, nil
+	} else if errors.As(tcpErr, &reachabilityErr) {
+		return Unreachable, nil
+	}
+	// The error is not related to the connectivity checks.
+	return Unexpected, tcpErr
+}
+
+// CheckServerReachable determines whether the server at `host:port` is reachable over TCP.
+// Returns an error if the server is unreachable.
+func CheckServerReachable(host string, port int) error {
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, strconv.Itoa(port)), reachabilityTimeout)
+	if err != nil {
+		return err
+	}
+	conn.Close()
+	return nil
+}

--- a/outline/shadowsocks/config.go
+++ b/outline/shadowsocks/config.go
@@ -12,21 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Deprecated: Please use
+// [github.com/Jigsaw-Code/outline-go-tun2socks/outline/client] instead.
 package shadowsocks
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-
 	"github.com/Jigsaw-Code/outline-ss-server/client"
 	"github.com/eycorsican/go-tun2socks/common/log"
 )
 
 // Config represents a shadowsocks server configuration.
 // Exported via gobind.
-//
-// Deprecated: Please use MakeClient().
 type Config struct {
 	Host       string
 	Port       int
@@ -35,38 +31,13 @@ type Config struct {
 	Prefix     []byte
 }
 
-// Must match the ShadowsocksSessionConfig interface in Typescript.
-type configJSON struct {
-	Host     string
-	Port     uint16
-	Password string
-	Method   string
-	Prefix   string
-}
-
 // Client provides a transparent container for [client.Client] that
 // is exportable (as an opaque object) via gobind.
 type Client struct {
 	client.Client
 }
 
-// The prefix is an 8-bit-clean byte sequence, stored in the codepoint
-// values of a unicode string, which arrives here encoded in UTF-8.
-func extractPrefixBytes(prefixUtf8 string) ([]byte, error) {
-	prefixRunes := []rune(prefixUtf8)
-	prefixBytes := make([]byte, len(prefixRunes))
-	for i, r := range prefixRunes {
-		if (r & 0xFF) != r {
-			return nil, fmt.Errorf("character out of range: %d", r)
-		}
-		prefixBytes[i] = byte(r)
-	}
-	return prefixBytes, nil
-}
-
 // NewClient provides a gobind-compatible wrapper for [client.NewClient].
-//
-// Deprecated: Please use MakeClient().
 func NewClient(config *Config) (*Client, error) {
 	c, err := client.NewClient(config.Host, config.Port, config.Password, config.CipherName)
 	if err != nil {
@@ -78,38 +49,4 @@ func NewClient(config *Config) (*Client, error) {
 	}
 
 	return &Client{c}, nil
-}
-
-// newConfig converts a UTF-8 JSON string into a Config struct.
-// A string is used to ensure that configs can be passed through gobind.
-func newConfig(s string) (*Config, error) {
-	var parsed configJSON
-	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
-		return nil, err
-	}
-	if len(parsed.Host) == 0 || parsed.Port == 0 || len(parsed.Method) == 0 || len(parsed.Password) == 0 {
-		return nil, errors.New("missing mandatory field")
-	}
-	config := Config{
-		Host:       parsed.Host,
-		Port:       int(parsed.Port),
-		CipherName: parsed.Method,
-		Password:   parsed.Password,
-	}
-	prefixBytes, err := extractPrefixBytes(parsed.Prefix)
-	if err != nil {
-		return nil, fmt.Errorf("prefix parsing failed: %w", err)
-	}
-	config.Prefix = prefixBytes
-	return &config, nil
-}
-
-// MakeClient provides a gobind-compatible wrapper for [client.NewClient].
-// [configStr] contains a JSON configuration object.
-func MakeClient(configStr string) (*Client, error) {
-	config, err := newConfig(configStr)
-	if err != nil {
-		return nil, err
-	}
-	return NewClient(config)
 }

--- a/outline/shadowsocks/config_test.go
+++ b/outline/shadowsocks/config_test.go
@@ -73,3 +73,112 @@ func Test_extractPrefixBytes(t *testing.T) {
 		})
 	}
 }
+
+func Test_newConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    *Config
+		wantErr bool
+	}{
+		{
+			name:  "normal config",
+			input: `{"host":"192.0.2.1","port":12345,"method":"some-cipher","password":"abcd1234"}`,
+			want: &Config{
+				Host:       "192.0.2.1",
+				Port:       12345,
+				CipherName: "some-cipher",
+				Password:   "abcd1234",
+			},
+		},
+		{
+			name:  "normal config with prefix",
+			input: `{"host":"192.0.2.1","port":12345,"method":"some-cipher","password":"abcd1234","prefix":"abc 123"}`,
+			want: &Config{
+				Host:       "192.0.2.1",
+				Port:       12345,
+				CipherName: "some-cipher",
+				Password:   "abcd1234",
+				Prefix:     []byte("abc 123"),
+			},
+		},
+		{
+			name:  "normal config with extra fields",
+			input: `{"extra_field":"ignored","host":"192.0.2.1","port":12345,"method":"some-cipher","password":"abcd1234"}`,
+			want: &Config{
+				Host:       "192.0.2.1",
+				Port:       12345,
+				CipherName: "some-cipher",
+				Password:   "abcd1234",
+			},
+		},
+		{
+			name:    "missing host",
+			input:   `{"port":12345,"method":"some-cipher","password":"abcd1234"}`,
+			wantErr: true,
+		},
+		{
+			name:    "missing port",
+			input:   `{"host":"192.0.2.1","method":"some-cipher","password":"abcd1234"}`,
+			wantErr: true,
+		},
+		{
+			name:    "missing method",
+			input:   `{"host":"192.0.2.1","port":12345,"password":"abcd1234"}`,
+			wantErr: true,
+		},
+		{
+			name:    "missing password",
+			input:   `{"host":"192.0.2.1","port":12345,"method":"some-cipher"}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty host",
+			input:   `{"host":"","port":12345,"method":"some-cipher","password":"abcd1234"}`,
+			wantErr: true,
+		},
+		{
+			name:    "zero port",
+			input:   `{"host":"192.0.2.1","port":0,"method":"some-cipher","password":"abcd1234"}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty method",
+			input:   `{"host":"192.0.2.1","port":12345,"method":"","password":"abcd1234"}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty password",
+			input:   `{"host":"192.0.2.1","port":12345,"method":"some-cipher","password":""}`,
+			wantErr: true,
+		},
+		{
+			name:    "port -1",
+			input:   `{"host":"192.0.2.1","port":-1,"method":"some-cipher","password":"abcd1234"}`,
+			wantErr: true,
+		},
+		{
+			name:    "port 65536",
+			input:   `{"host":"192.0.2.1","port":65536,"method":"some-cipher","password":"abcd1234"}`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newConfig(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if got.Host != tt.want.Host ||
+				got.Port != tt.want.Port ||
+				got.CipherName != tt.want.CipherName ||
+				!bytes.Equal(got.Prefix, tt.want.Prefix) {
+				t.Errorf("newConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/outline/shadowsocks/config_test.go
+++ b/outline/shadowsocks/config_test.go
@@ -1,0 +1,75 @@
+// Copyright 2022 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shadowsocks
+
+import (
+	"bytes"
+	"testing"
+)
+
+func Test_extractPrefixBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name:  "basic",
+			input: "abc 123",
+			want:  []byte("abc 123"),
+		}, {
+			name:  "empty",
+			input: "",
+			want:  []byte{},
+		}, {
+			name:  "extended",
+			input: string([]rune{0, 1, 2, 126, 127, 128, 129, 254, 255}),
+			want:  []byte{0, 1, 2, 126, 127, 128, 129, 254, 255},
+		}, {
+			name:    "out of range 256",
+			input:   string([]rune{256}),
+			wantErr: true,
+		}, {
+			name:    "out of range 257",
+			input:   string([]rune{257}),
+			wantErr: true,
+		}, {
+			name:    "out of range 65537",
+			input:   string([]rune{65537}),
+			wantErr: true,
+		}, {
+			name:    "invalid UTF-8",
+			input:   "\xc3\x28",
+			wantErr: true,
+		}, {
+			name:    "invalid Unicode",
+			input:   "\xf8\xa1\xa1\xa1\xa1",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractPrefixBytes(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("extractPrefixBytes() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !bytes.Equal(got, tt.want) {
+				t.Errorf("extractPrefixBytes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This moves the burden of disassembling the ShadowsocksSessionConfig to Go, allowing the platform code to be simplified. In the future, this will allow the config format to evolve without requiring modifications to the platform code.

Replaces #106 due to ACL change.