### PR TITLE
Make errors an enum type

### DIFF
--- a/outline/connectivity/connectivity.go
+++ b/outline/connectivity/connectivity.go
@@ -48,7 +48,7 @@ type reachabilityError struct {
 // the current network. Parallelizes the execution of TCP and UDP checks, selects the appropriate
 // error code to return accounting for transient network failures.
 // Returns an error if an unexpected error ocurrs.
-func CheckConnectivity(client *outline.Client) (int, error) {
+func CheckConnectivity(client *outline.Client) (neterrors.Error, error) {
 	// Start asynchronous UDP support check.
 	udpChan := make(chan error)
 	go func() {

--- a/outline/electron/main.go
+++ b/outline/electron/main.go
@@ -88,16 +88,16 @@ func main() {
 	// Validate proxy flags
 	if *args.proxyHost == "" {
 		log.Errorf("Must provide a Shadowsocks proxy host name or IP address")
-		os.Exit(neterrors.IllegalConfiguration)
+		os.Exit(neterrors.IllegalConfiguration.Number())
 	} else if *args.proxyPort <= 0 || *args.proxyPort > 65535 {
 		log.Errorf("Must provide a valid Shadowsocks proxy port [1:65535]")
-		os.Exit(neterrors.IllegalConfiguration)
+		os.Exit(neterrors.IllegalConfiguration.Number())
 	} else if *args.proxyPassword == "" {
 		log.Errorf("Must provide a Shadowsocks proxy password")
-		os.Exit(neterrors.IllegalConfiguration)
+		os.Exit(neterrors.IllegalConfiguration.Number())
 	} else if *args.proxyCipher == "" {
 		log.Errorf("Must provide a Shadowsocks proxy encryption cipher")
-		os.Exit(neterrors.IllegalConfiguration)
+		os.Exit(neterrors.IllegalConfiguration.Number())
 	}
 
 	config := shadowsocks.Config{
@@ -114,7 +114,7 @@ func main() {
 	for i, r := range prefixRunes {
 		if (r & 0xFF) != r {
 			log.Errorf("Character out of range: %r", r)
-			os.Exit(neterrors.IllegalConfiguration)
+			os.Exit(neterrors.IllegalConfiguration.Number())
 		}
 		config.Prefix[i] = byte(r)
 	}
@@ -122,7 +122,7 @@ func main() {
 	client, err := shadowsocks.NewClient(&config)
 	if err != nil {
 		log.Errorf("Failed to construct Shadowsocks client: %v", err)
-		os.Exit(neterrors.IllegalConfiguration)
+		os.Exit(neterrors.IllegalConfiguration.Number())
 	}
 
 	if *args.checkConnectivity {
@@ -131,7 +131,7 @@ func main() {
 		if err != nil {
 			log.Errorf("Failed to perform connectivity checks: %v", err)
 		}
-		os.Exit(connErrCode)
+		os.Exit(connErrCode.Number())
 	}
 
 	// Open TUN device
@@ -139,7 +139,7 @@ func main() {
 	tunDevice, err := tun.OpenTunDevice(*args.tunName, *args.tunAddr, *args.tunGw, *args.tunMask, dnsResolvers, persistTun)
 	if err != nil {
 		log.Errorf("Failed to open TUN device: %v", err)
-		os.Exit(neterrors.SystemMisconfigured)
+		os.Exit(neterrors.SystemMisconfigured.Number())
 	}
 	// Output packets to TUN device
 	core.RegisterOutputFn(tunDevice.Write)
@@ -160,7 +160,7 @@ func main() {
 		_, err := io.CopyBuffer(lwipWriter, tunDevice, make([]byte, mtu))
 		if err != nil {
 			log.Errorf("Failed to write data to network stack: %v", err)
-			os.Exit(neterrors.Unexpected)
+			os.Exit(neterrors.Unexpected.Number())
 		}
 	}()
 

--- a/outline/neterrors/neterrors.go
+++ b/outline/neterrors/neterrors.go
@@ -18,19 +18,25 @@
 // provide its own standalone API, leaving translations to the consumer.
 package neterrors
 
+type Error int
+
+func (e Error) Number() int {
+	return int(e)
+}
+
 // Outline error codes. Must be kept in sync with definitions in https://github.com/Jigsaw-Code/outline-client/blob/master/src/www/model/errors.ts
 const (
-	NoError                     = 0
-	Unexpected                  = 1
-	NoVPNPermissions            = 2 // Unused
-	AuthenticationFailure       = 3
-	UDPConnectivity             = 4
-	Unreachable                 = 5
-	VpnStartFailure             = 6  // Unused
-	IllegalConfiguration        = 7  // Electron only
-	ShadowsocksStartFailure     = 8  // Unused
-	ConfigureSystemProxyFailure = 9  // Unused
-	NoAdminPermissions          = 10 // Unused
-	UnsupportedRoutingTable     = 11 // Unused
-	SystemMisconfigured         = 12 // Electron only
+	NoError                     Error = 0
+	Unexpected                  Error = 1
+	NoVPNPermissions            Error = 2 // Unused
+	AuthenticationFailure       Error = 3
+	UDPConnectivity             Error = 4
+	Unreachable                 Error = 5
+	VpnStartFailure             Error = 6  // Unused
+	IllegalConfiguration        Error = 7  // Electron only
+	ShadowsocksStartFailure     Error = 8  // Unused
+	ConfigureSystemProxyFailure Error = 9  // Unused
+	NoAdminPermissions          Error = 10 // Unused
+	UnsupportedRoutingTable     Error = 11 // Unused
+	SystemMisconfigured         Error = 12 // Electron only
 )

--- a/outline/shadowsocks/api.go
+++ b/outline/shadowsocks/api.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/Jigsaw-Code/outline-go-tun2socks/outline"
 	"github.com/Jigsaw-Code/outline-go-tun2socks/outline/connectivity"
+	"github.com/Jigsaw-Code/outline-go-tun2socks/outline/neterrors"
 	"github.com/Jigsaw-Code/outline-internal-sdk/transport"
 	"github.com/Jigsaw-Code/outline-internal-sdk/transport/shadowsocks"
 	"github.com/Jigsaw-Code/outline-internal-sdk/transport/shadowsocks/client"
@@ -78,7 +79,7 @@ const reachabilityTimeout = 10 * time.Second
 // the current network. Parallelizes the execution of TCP and UDP checks, selects the appropriate
 // error code to return accounting for transient network failures.
 // Returns an error if an unexpected error ocurrs.
-func CheckConnectivity(client *Client) (int, error) {
+func CheckConnectivity(client *Client) (neterrors.Error, error) {
 	return connectivity.CheckConnectivity(client)
 }
 


### PR DESCRIPTION
There's a better way to do enums in Go.

The way we do errors in this API is still problematic, but at least this is a bit better.