### PR TITLE
fix: 💊 make sure gomobile can export CheckConnectivity and NewClient

### DIFF
--- a/outline/electron/main.go
+++ b/outline/electron/main.go
@@ -103,7 +103,7 @@ func main() {
 		if err != nil {
 			log.Errorf("Failed to perform connectivity checks: %v", err)
 		}
-		os.Exit(connErrCode.Number())
+		os.Exit(connErrCode)
 	}
 
 	// Open TUN device


### PR DESCRIPTION
Outline Client (and other 3-rd party customers) is already referencing the following APIs (Android JNI interface) exported by `gomobile`. But due to the recent refactoring, we introduced types that are not recognized by `gomobile`.

<img width="642" alt="image" src="https://user-images.githubusercontent.com/93548144/232151618-de7c91eb-2ee6-444e-bbe0-023262af2149.png">

In this PR, I re-exported these functions (together with the new `NewClientFromJSON`) by using the built-in types. Here is the exported Android JNI interface:

<img width="642" alt="image" src="https://user-images.githubusercontent.com/93548144/232151764-5bf0db03-a5dd-4ed7-a234-199c02a9e13d.png">
