### PR TITLE
fix: 💊 re-export APIs used by Outline Client

### DIFF
--- a/outline/electron/main.go
+++ b/outline/electron/main.go
@@ -103,7 +103,7 @@ func main() {
 		if err != nil {
 			log.Errorf("Failed to perform connectivity checks: %v", err)
 		}
-		os.Exit(connErrCode.Number())
+		os.Exit(connErrCode)
 	}
 
 	// Open TUN device

--- a/outline/shadowsocks/client.go
+++ b/outline/shadowsocks/client.go
@@ -123,7 +123,7 @@ const reachabilityTimeout = 10 * time.Second
 // Returns an error if an unexpected error ocurrs.
 func CheckConnectivity(client *Client) (int, error) {
 	errCode, err := connectivity.CheckConnectivity((*outline.Client)(client))
-	return int(errCode), err
+	return errCode.Number(), err
 }
 
 // CheckServerReachable determines whether the server at `host:port` is reachable over TCP.


### PR DESCRIPTION
Outline Client is referencing the following APIs (Android JNI interface as an example) exported by `gomobile`.

<img width="642" alt="image" src="https://user-images.githubusercontent.com/93548144/232151618-de7c91eb-2ee6-444e-bbe0-023262af2149.png">

But due to the recent refactoring, we introduced types that are not recognized by `gomobile`. This is the only function exported in `master` branch now:

<img width="646" alt="image" src="https://user-images.githubusercontent.com/93548144/232152396-6cf278ab-f45b-448a-adb9-c03b13772eb7.png">

In this PR, I re-exported these functions (together with the new `NewClientFromJSON`) by using the built-in types. Here is the exported Android JNI interface:

<img width="635" alt="image" src="https://user-images.githubusercontent.com/93548144/232151977-ad6bd330-4bc5-4383-b6ef-49dce4dc1853.png">

/cc @sbruens , although the required APIs are re-exported, some of the data types still need to be updated:

* [`OutlineTunnel`](https://github.com/Jigsaw-Code/outline-client/blob/master/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnel.java#L49) -> `Tunnel`
* [`Tun2socksOutlineTunnel`](https://github.com/Jigsaw-Code/outline-client/blob/master/src/cordova/apple/OutlineAppleLib/Sources/PacketTunnelProviderSources/PacketTunnelProvider.m#L39) -> `Tun2socksTunnel`

Related PR: #118 